### PR TITLE
Fixed exception when only stderr is available.

### DIFF
--- a/lib/util/test_binary.js
+++ b/lib/util/test_binary.js
@@ -1,4 +1,3 @@
-
 module.exports = exports;
 
 var fs = require('fs')
@@ -34,7 +33,7 @@ module.exports.validate = function(opts,callback) {
     log.info("validate","Running test command: '" + shell_cmd + ' ' + args.join(' '));
     cp.execFile(shell_cmd, args, function(err, stdout, stderr) {
         if (err || stderr) {
-            return callback(new Error(err.message || stderr));
+            return callback(new Error(err && err.message || stderr));
         }        
         return callback();
     });


### PR DESCRIPTION
Without checking if error is not null I got weird exceptions from node-pre-gyp itself, which caused my `npm install` to fail miserably.
