### PR TITLE
shebang magic

### DIFF
--- a/bin/node-pre-gyp
+++ b/bin/node-pre-gyp
@@ -1,5 +1,5 @@
 #!/bin/sh
-// 2>/dev/null; if [[ `which nodejs` ]]; then exec nodejs "$0" "$@"; else exec node "$0" "$@";fi;
+// 2>/dev/null; if [ `which nodejs` ]; then exec nodejs "$0" "$@"; else exec node "$0" "$@";fi;
 ;(function () {
 
 /**


### PR DESCRIPTION
Attempt to support debian systems which have renamed `node` to `nodejs`

Trying to fix https://github.com/mapbox/node-sqlite3/issues/256

To avoid errors like:

```
npm WARN This failure might be due to the use of legacy binary "node"
npm WARN For further explanations, please read
/usr/share/doc/nodejs/README.Debian
```

README.Debian states:

```
nodejs command
--------------

The upstream name for the Node.js interpreter command is "node".
In Debian the interpreter command has been changed to "nodejs".

This was done to prevent a namespace collision: other commands use
the same name in their upstreams, such as ax25-node from the "node"
package.

Scripts calling Node.js as a shell command must be changed to instead
use the "nodejs" command.
```
