### PR TITLE
node-webkit: validate the binary module only

### DIFF
--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -19,10 +19,9 @@ function testbinary(gyp, argv, callback) {
     }
     var package_json = JSON.parse(fs.readFileSync('./package.json'));
     var opts = versioning.evaluate(package_json, gyp.opts);
+    var binary_module = path.join(opts.module_path, opts.module_name + '.node');
     var nw = (opts.runtime && opts.runtime === 'node-webkit'); 
     if (nw) {
-        // TODO - solve https://github.com/mapbox/node-pre-gyp/issues/63
-        // for node-webkit
         options.timeout = 5000;
         if (process.platform === 'darwin') {
             shell_cmd = 'node-webkit';
@@ -31,10 +30,10 @@ function testbinary(gyp, argv, callback) {
         } else {
             shell_cmd = 'nw';
         }
-        var moduleDir = process.cwd();
-        var appDir = path.join(__dirname, 'nw-pre-gyp');
+        var modulePath = path.join(process.cwd(), binary_module);
+        var appDir = path.join(__dirname, 'util', 'nw-pre-gyp');
         args.push(appDir);
-        args.push(moduleDir);
+        args.push(modulePath);
         log.info("validate","Running test command: '" + shell_cmd + ' ' + args.join(' ') + "'");
         cp.execFile(shell_cmd, args, options, function(err, stdout, stderr) {
             // check for normal timeout for node-webkit
@@ -56,7 +55,6 @@ function testbinary(gyp, argv, callback) {
         shell_cmd = process.execPath;
     } else return callback();
     args.push('--eval');
-    var binary_module = path.join(opts.module_path,opts.module_name + '.node');
     args.push("require('" + binary_module +"')");
     log.info("validate","Running test command: '" + shell_cmd + ' ' + args.join(' ') + "'");
     cp.execFile(shell_cmd, args, options, function(err, stdout, stderr) {


### PR DESCRIPTION
Fixes #63 for node-webkit.
