### PR TITLE
use a valid value for the example of `--target-platform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Options include:
  - `--fallback-to-build`: fallback to building from source if pre-built binary is not available
  - `--target=0.10.25`: Pass the target node or node-webkit version to compile against
  - `--target_arch=ia32`: Pass the target arch and override the host `arch`. Valid values are 'ia32','x64', or `arm`.
- - `--target_platform=ia32`: Pass the target platform and override the host `platform`. Valid values are `linux`, `darwin`, `win32`, `sunos`, `freebsd`, `openbsd`, and `aix`.
+ - `--target_platform=win32`: Pass the target platform and override the host `platform`. Valid values are `linux`, `darwin`, `win32`, `sunos`, `freebsd`, `openbsd`, and `aix`.
 
 Both `--build-from-source` and `--fallback-to-build` can be passed alone or they can provide values. You can pass `--fallback-to-build=false` to override the option as declared in package.json. In addition to being able to pass `--build-from-source` you can also pass `--build-from-source=myapp` where `myapp` is the name of your module.
 


### PR DESCRIPTION
Valid values are `linux`, `darwin`, `win32`, `sunos`, `freebsd`, `openbsd`, and `aix`.

The value `ia32` is a result of unedited copy-and-paste from the above line.
