### PR TITLE
support Atom Shell as a runtime

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -10,7 +10,7 @@ function get_node_abi(runtime, target) {
     if (target) {
         // abi_crosswalk generated with ./scripts/abi_crosswalk.js
         var abi = '';
-        if (runtime === 'node-webkit') {
+        if (['node-webkit', 'atom-shell'].indexOf(runtime) > -1) {
             return runtime + '-v' + target;
         } else {
             if (abi_crosswalk[target]) {
@@ -34,12 +34,12 @@ function get_node_abi(runtime, target) {
             return 'v8-' + abi;
         }
     } else {
-        if (runtime === 'node-webkit') {
-            if (typeof process.versions['node-webkit'] === 'undefined') {
+        if (['node-webkit', 'atom-shell'].indexOf(runtime) > -1) {
+            if (typeof process.versions[runtime] === 'undefined') {
                 // erroneous CLI call
-                throw new Error("Empty target version is not supported if node-webkit is the target.");
+                throw new Error("Empty target version is not supported if " + runtime + " is the target.");
             }
-            return runtime + '-v' + process.versions['node-webkit'];
+            return runtime + '-v' + process.versions[runtime];
         }
         // process.versions.modules added in >= v0.10.4 and v0.11.7
         // https://github.com/joyent/node/commit/ccabd4a6fa8a6eb79d29bc3bbe9fe2b6531c2d8e
@@ -118,7 +118,11 @@ module.exports.evaluate = function(package_json,options) {
     validate_config(package_json);
     var v = package_json.version;
     var module_version = semver.parse(v);
-    var runtime = options.runtime || (process.versions['node-webkit'] ? 'node-webkit' : 'node');
+    var runtime = options.runtime || (
+        process.versions['atom-shell'] ? 'atom-shell' : (
+            process.versions['node-webkit'] ? 'node-webkit' : 'node'
+        )
+    );
     var opts = {
           name: package_json.name
         , configuration: Boolean(options.debug) ? 'Debug' : 'Release'

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -34,6 +34,13 @@ function get_node_abi(runtime, target) {
             return 'v8-' + abi;
         }
     } else {
+        if (runtime === 'node-webkit') {
+            if (typeof process.versions['node-webkit'] === 'undefined') {
+                // erroneous CLI call
+                throw new Error("Empty target version is not supported if node-webkit is the target.");
+            }
+            return runtime + '-v' + process.versions['node-webkit'];
+        }
         // process.versions.modules added in >= v0.10.4 and v0.11.7
         // https://github.com/joyent/node/commit/ccabd4a6fa8a6eb79d29bc3bbe9fe2b6531c2d8e
         return process.versions.modules ? runtime+'-v' + (+process.versions.modules) :

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-pre-gyp",
   "description": "Node.js native addon binary install tool",
-  "version" : "0.5.25",
+  "version" : "0.5.26",
   "keywords": [
     "native",
     "addon",


### PR DESCRIPTION
The following additions have to be implemented to support Atom Shell and fix #110:

* [x] add atom-shell-related versioning
* [ ] add atom-shell-related [building of native modules](https://github.com/atom/atom-shell/blob/master/docs/tutorial/using-native-node-modules.md#the-node-gyp-way)
* [ ] add atom-shell-relating testing of builds
* [ ] add atom-shell-related docs (mostly in `README`)

**Note:** this pull request also fixes #111 because is based on its branch.