### PR TITLE
Properly escape path when passing to shell

### DIFF
--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -17,7 +17,7 @@ function testbinary(gyp, argv, callback) {
     var opts = versioning.evaluate(package_json, gyp.opts);
     // ensure on windows that / are used for require path
     var binary_module = opts.module.replace(/\\/g, '/');
-    var nw = (opts.runtime && opts.runtime === 'node-webkit'); 
+    var nw = (opts.runtime && opts.runtime === 'node-webkit');
     if (nw) {
         options.timeout = 5000;
         if (process.platform === 'darwin') {
@@ -60,7 +60,7 @@ function testbinary(gyp, argv, callback) {
         return callback();
     }
     args.push('--eval');
-    args.push("require('" + binary_module +"')");
+    args.push("require('" + binary_module.replace(/\'/g, '\\\'') +"')");
     log.info("validate","Running test command: '" + shell_cmd + ' ' + args.join(' ') + "'");
     cp.execFile(shell_cmd, args, options, function(err, stdout, stderr) {
         if (err) {


### PR DESCRIPTION
fixes #113
- properly escape path
