### PR TITLE
Allow dots in s3 buckets

### DIFF
--- a/lib/util/s3_setup.js
+++ b/lib/util/s3_setup.js
@@ -3,15 +3,24 @@ module.exports = exports;
 
 var url = require('url')
 
+var URI_REGEX="^(.*)\.(s3(?:-.*)?)\.amazonaws\.com$";
+
 module.exports.detect = function(to,config) {
     var uri = url.parse(to);
-    var url_paths = uri.hostname.split('.');
+    var hostname_matches = uri.hostname.match(URI_REGEX);
+
     config.prefix = (!uri.pathname || uri.pathname == '/') ? '' : uri.pathname.replace('/','');
-    if (!config.bucket && url_paths && url_paths[0]) {
-        config.bucket = url_paths[0];
+
+    if(!hostname_matches) {
+      return;
     }
-    if (!config.region && url_paths && url_paths[1]) {
-        var s3_domain = url_paths[1];
+
+    if (!config.bucket) {
+        config.bucket = hostname_matches[1];
+    }
+
+    if (!config.region) {
+        var s3_domain = hostname_matches[2];
         if (s3_domain.slice(0,3) == 's3-' &&
             s3_domain.length >= 3) {
             // it appears the region is explicit in the url


### PR DESCRIPTION
Sadly, an s3 bucket I have to use has dots in it, e.g. "foo.bar.baz". Currently node-pre-gyp interprets this as meaning my bucket is "foo", and it is unable to detect my s3 region.

This pull request parses my s3 host correctly, and the one used by your test apps. I'd include test coverage, but I don't have an s3 bucket I can donate to the project. Without unit tests to guide me, I tested my changes manually with the following script:

``` javascript
var s3_setup = require('./lib/util/s3_setup.js');

var url_with_dots = "https://bucket.with.dots.s3.amazonaws.com/prefix";
var url_without_dots = "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com";

dots_result = {};
no_dots_result = {};

s3_setup.detect(url_with_dots, dots_result);
s3_setup.detect(url_without_dots, no_dots_result);

console.log(url_with_dots, dots_result);
console.log(url_without_dots, no_dots_result);
```

Please let me know if there's anything I can do to help get this merged. Currently I have to specify my bucket in a `~/.node-pre-gyp` file, which is unsatisfying.
