### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "binary"
   ],
   "author": "Dane Springmeyer <dane@mapbox.com>",
+  "license" : "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/mapbox/node-pre-gyp.git"


### PR DESCRIPTION
For automated license discovery tools (like License Finder) to work, we need to include license information in package.json. It appears you're using the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause).

By the way, you haven't fully filled in the template in LICENSE. (It still says "{organization}" in the third bullet.)

Thanks!
