### PR TITLE
Fix issue with require validation not working on windows 7

### DIFF
--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -62,7 +62,7 @@ function testbinary(gyp, argv, callback) {
         return callback();
     }
     args.push('--eval');
-    args.push("require('" + binary_module.replace(/\'/g, '\\\'') +"')");
+    args.push("'require(\\'" + binary_module.replace(/\'/g, '\\\'') +"\\')'");
     log.info("validate","Running test command: '" + shell_cmd + ' ' + args.join(' ') + "'");
     cp.execFile(shell_cmd, args, options, function(err, stdout, stderr) {
         if (err) {


### PR DESCRIPTION
There is an issue where the module is not found by trying to require it with `--eval` as it is now.

This fixes it and continues to work on linux (need to double check on mac).