### PR TITLE
Allow passing args directly to gyp

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -61,7 +61,7 @@ function build(gyp, argv, callback) {
         if (val) {
             node_pre_gyp_options.push('--' + key + '=' + val);
         } else {
-            return callback(new Error("Option " + o + " required but not found by node-pre-gyp"));
+            return callback(new Error("Option " + key + " required but not found by node-pre-gyp"));
         }
     });
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -9,52 +9,114 @@ var compile = require('./util/compile.js');
 var versioning = require('./util/versioning.js');
 var fs = require('fs');
 
+/*
+
+Here we gather node-pre-gyp generated options (from versioning) and pass them along to node-gyp.
+
+We massage the args and options slightly to account for differences in what commands mean between
+node-pre-gyp and node-gyp (e.g. see the difference between "build" and "rebuild" below)
+
+Keep in mind: the values inside `argv` and `gyp.opts` below are different depending on whether
+node-pre-gyp is called directory, or if it is called in a `run-script` phase of npm.
+
+We also try to preserve any command line options that might have been passed to npm or node-pre-gyp.
+But this is fairly difficult without passing way to much through. For example `gyp.opts` contains all
+the process.env and npm pushes a lot of variables into process.env which node-pre-gyp inherits. So we have
+to be very selective about what we pass through.
+
+For example:
+
+`npm install --build-from-source` will give:
+
+argv == [ 'rebuild' ]
+gyp.opts.argv == { remain: [ 'install' ],
+  cooked: [ 'install', '--fallback-to-build' ],
+  original: [ 'install', '--fallback-to-build' ] }
+
+`./bin/node-pre-gyp build` will give:
+
+argv == []
+gyp.opts.argv == { remain: [ 'build' ],
+  cooked: [ 'build' ],
+  original: [ '-C', 'test/app1', 'build' ] }
+
+*/
+
+// select set of node-pre-gyp versioning info
+// to share with node-gyp
+var share_with_node_gyp = [
+  'module',
+  'module_name',
+  'module_path',
+];
+
 function build(gyp, argv, callback) {
-    var gyp_args = [];
-    if (argv.length && argv[0] == 'rebuild') {
-        gyp_args.push('rebuild');
-    } else {
-        gyp_args.push('configure');
-        gyp_args.push('build');
-    }
-    var package_json = JSON.parse(fs.readFileSync('./package.json'));
-    var opts = versioning.evaluate(package_json, gyp.opts);
-    // options look different depending on whether node-pre-gyp is called directly
-    // or whether it is called from npm install, hence the following line.
-    // TODO: check if this is really necessary with latest npm/nopt versions
-    var original_args = (typeof(gyp.opts.argv.original) === 'string') ? JSON.parse(gyp.opts.argv).original : gyp.opts.argv.original || [];
-    // add command line options to existing opts
-    original_args.forEach(function(opt) {
-        // we ignore any args like 'install' since we know
-        // we are either running 'build' or 'rebuild' but we
-        // do want to pass along to node-gyp/nw-gyp any command
-        // line options like --option or --option=value passed in
-        if (opt.length > 2 && opt.slice(0,2) == '--') {
-            var parts = opt.split('=');
-            if (parts.length > 1) {
-                var key = parts[0];
-                opts[key.slice(2)] = parts[1];
-            }
-        }
-    });
-    var known_gyp_args = ['dist-url','python','nodedir','msvs_version'];
-    // in addition, pass along known node-gyp options
-    known_gyp_args.forEach(function(arg) {
-        var val = gyp.opts[arg] || gyp.opts[arg.replace('-','_')];
+
+    // Collect node-pre-gyp specific variables to pass to node-gyp
+    var node_pre_gyp_options = [];
+    // generate custom node-pre-gyp versioning info
+    var opts = versioning.evaluate(JSON.parse(fs.readFileSync('./package.json')), gyp.opts);
+    share_with_node_gyp.forEach(function(key) {
+        var val = opts[key];
         if (val) {
-            opts[arg] = val;
+            node_pre_gyp_options.push('--' + key + '=' + val);
+        } else {
+            return callback(new Error("Option " + o + " required but not found by node-pre-gyp"));
         }
     });
 
-    var command_line_args = [];
-    // turn back into command line options
-    Object.keys(opts).forEach(function(o) {
-        var val = opts[o];
-        if (val) {
-            command_line_args.push('--' + o + '=' + val);
+    // Collect options that follow the special -- which disables nopt parsing
+    var unparsed_options = [];
+    var double_hyphen_found = false;
+    gyp.opts.argv.original.forEach(function(opt) {
+        if (double_hyphen_found) {
+            unparsed_options.push(opt);
+        }
+        if (opt == '--') {
+            double_hyphen_found = true;
         }
     });
-    compile.run_gyp(gyp_args.concat(command_line_args),opts,function(err) {
-        return callback(err);
+
+    // We try respect and pass through remaining command
+    // line options (like --foo=bar) to node-gyp
+    var cooked = gyp.opts.argv.cooked;
+    var node_gyp_options = [];
+    cooked.forEach(function(value) {
+        if (value.length > 2 && value.slice(0,2) == '--') {
+            var key = value.slice(2);
+            var val = cooked[cooked.indexOf(value)+1];
+            if (val && val.indexOf('--') === -1) { // handle '--foo=bar' or ['--foo','bar']
+                node_gyp_options.push('--' + key + '=' + val);
+            } else { // pass through --foo
+                node_gyp_options.push(value);
+            }
+        }
     });
+
+    var final_args = ['configure'].concat(node_gyp_options).concat(node_pre_gyp_options);
+    var configure_options = [];
+    if (unparsed_options.length > 0) {
+        configure_options = final_args.
+                      concat(['--']).
+                      concat(unparsed_options);
+    }
+
+    // Form up commands to pass to node-gyp:
+    // We map `node-pre-gyp build` to `node-gyp configure build` so that we do not
+    // trigger a clean and therefore do not pay the penalty of a full recompile
+    var node_gyp_command = 'build';
+    if (argv.length && (argv.indexOf('rebuild') > -1)) {
+        // here we map `node-pre-gyp rebuild` to `node-gyp rebuild` which internally means
+        // "clean + configure + build" and triggers a full recompile
+        node_gyp_command = 'rebuild';
+    }
+
+    compile.run_gyp(configure_options.concat(final_args),opts,function(err) {
+        if (err) return callback(err);
+        compile.run_gyp([node_gyp_command].concat(final_args).concat(node_pre_gyp_options),opts,function(err) {
+            return callback(err);
+        });
+
+    });
+
 }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -99,7 +99,7 @@ describe('build', function() {
             run('node-pre-gyp rebuild --fallback-to-build --loglevel=silent', app, {}, function(err,stdout,stderr) {
                 if (err) return on_error(err,stdout,stderr);
                 assert.ok(stdout.search(app.name+'.node') > -1);
-                if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                     assert.equal(stderr,'');
                 }
                 done();
@@ -131,7 +131,7 @@ describe('build', function() {
             it(app.name + ' cleans up after installing custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function(done) {
                 run('node-pre-gyp clean --target='+previous_version, app, opts, function(err,stdout,stderr) {
                     if (err) return on_error(err,stdout,stderr);
-                    if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                         assert.equal(stderr,'');
                     }
                     assert.notEqual(stdout,'');
@@ -150,7 +150,7 @@ describe('build', function() {
             run('node-pre-gyp rebuild --fallback-to-build --target='+process.versions.node, app, {}, function(err,stdout,stderr) {
                 if (err) return on_error(err,stdout,stderr);
                 assert.ok(stdout.search(app.name+'.node') > -1);
-                if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                     assert.equal(stderr,'');
                 }
                 done();
@@ -160,7 +160,7 @@ describe('build', function() {
         it(app.name + ' is found ' + app.args, function(done) {
             run('node-pre-gyp reveal module_path --silent', app, {}, function(err,stdout,stderr) {
                 if (err) return on_error(err,stdout,stderr);
-                if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                     assert.equal(stderr,'');
                 }
                 var module_path = stdout.trim();
@@ -175,7 +175,7 @@ describe('build', function() {
         it(app.name + ' passes tests ' + app.args, function(done) {
             run('npm test', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                 if (err) return on_error(err,stdout,stderr);
-                if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                     assert.equal(stderr,'');
                 }
                 assert.notEqual(stdout,'');
@@ -186,7 +186,7 @@ describe('build', function() {
         it(app.name + ' packages ' + app.args, function(done) {
             run('node-pre-gyp package', app, {}, function(err,stdout,stderr) {
                 if (err) return on_error(err,stdout,stderr);
-                if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                     assert.equal(stderr,'');
                 }
                 done();
@@ -196,7 +196,7 @@ describe('build', function() {
         it(app.name + ' package is valid ' + app.args, function(done) {
             run('node-pre-gyp testpackage', app, {}, function(err,stdout,stderr) {
                 if (err) return on_error(err,stdout,stderr);
-                if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                     assert.equal(stderr,'');
                 }
                 done();
@@ -208,7 +208,7 @@ describe('build', function() {
             it(app.name + ' publishes ' + app.args, function(done) {
                 run('node-pre-gyp unpublish publish', app, {}, function(err,stdout,stderr) {
                     if (err) return on_error(err,stdout,stderr);
-                    if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                         assert.equal(stderr,'');
                     }
                     assert.notEqual(stdout,'');
@@ -224,7 +224,7 @@ describe('build', function() {
                     var package_name = stdout.trim();
                     run('node-pre-gyp info', app, {}, function(err,stdout,stderr) {
                         if (err) return on_error(err,stdout,stderr);
-                        if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                             assert.equal(stderr,'');
                         }
                         assert.ok(stdout.indexOf(package_name) > -1);
@@ -236,7 +236,7 @@ describe('build', function() {
             it(app.name + ' can be uninstalled ' + app.args, function(done) {
                 run('node-pre-gyp clean', app, {}, function(err,stdout,stderr) {
                     if (err) return on_error(err,stdout,stderr);
-                    if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                         assert.equal(stderr,'');
                     }
                     assert.notEqual(stdout,'');
@@ -247,7 +247,7 @@ describe('build', function() {
             it(app.name + ' can be installed via remote ' + app.args, function(done) {
                 run('npm install --fallback-to-build=false --silent', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                     if (err) return on_error(err,stdout,stderr);
-                    if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                         assert.equal(stderr,'');
                     }
                     assert.notEqual(stdout,'');
@@ -258,7 +258,7 @@ describe('build', function() {
             it(app.name + ' can be reinstalled via remote ' + app.args, function(done) {
                 run('npm install --update-binary --fallback-to-build=false --silent', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                     if (err) return on_error(err,stdout,stderr);
-                    if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                         assert.equal(stderr,'');
                     }
                     assert.notEqual(stdout,'');
@@ -269,7 +269,7 @@ describe('build', function() {
             it(app.name + ' via remote passes tests ' + app.args, function(done) {
                 run('npm test', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                     if (err) return on_error(err,stdout,stderr);
-                    if (stderr != "child_process: customFds option is deprecated, use stdio instead.\n") {
+                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
                         assert.equal(stderr,'');
                     }
                     assert.notEqual(stdout,'');


### PR DESCRIPTION
Refs #140 

 - this breaks up configure + build/rebuild stages
 - this adds support for passing opts to gyp directly and unchanged
 - this starts passing through more arbitrary options you might want
   to communicate to node-gyp
 - this starts limiting the node-pre-gyp internal variables that get
   passed to node-gyp to a very select set. Sorry if this breaks your
   app because you were depending on variabls no longer exposed. If this
   happened just post an issue and we'll consider adding suppor for the
   node-pre-gyp variables you need passed to node-gyp
