### PR TITLE
Add a property "download_host" in binary object 

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -139,7 +139,7 @@ function install(gyp, argv, callback) {
         } catch (err) {
             return callback(err);
         }
-        var from = opts.hosted_tarball;
+        var from = opts.download_tarball;
         var to = opts.module_path;
         var binary_module = path.join(to,opts.module_name + '.node');
         if (existsAsync(binary_module,function(found) {

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -256,6 +256,7 @@ module.exports.evaluate = function(package_json,options) {
         toolset : options.toolset || '' // address https://github.com/mapbox/node-pre-gyp/issues/119
     };
     opts.host = fix_slashes(eval_template(package_json.binary.host,opts));
+    opts.download_host = fix_slashes(eval_template(package_json.binary.download_host||opts.host,opts));
     opts.module_path = eval_template(package_json.binary.module_path,opts);
     // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably
     if (options.module_root) {
@@ -271,7 +272,7 @@ module.exports.evaluate = function(package_json,options) {
     opts.package_name = eval_template(package_name,opts);
     opts.staged_tarball = path.join('build/stage',opts.remote_path,opts.package_name);
     opts.hosted_path = url.resolve(opts.host,opts.remote_path);
-    opts.donwload_path = url.resolve(opts.download_host||opts.host,opts.remote_path);
+    opts.donwload_path = url.resolve(opts.download_host,opts.remote_path);
     opts.hosted_tarball = url.resolve(opts.hosted_path,opts.package_name);
     opts.download_tarball = url.resolve(opts.donwload_path,opts.package_name);
     return opts;

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -271,6 +271,8 @@ module.exports.evaluate = function(package_json,options) {
     opts.package_name = eval_template(package_name,opts);
     opts.staged_tarball = path.join('build/stage',opts.remote_path,opts.package_name);
     opts.hosted_path = url.resolve(opts.host,opts.remote_path);
+    opts.donwload_path = url.resolve(opts.download_host||opts.host,opts.remote_path);
     opts.hosted_tarball = url.resolve(opts.hosted_path,opts.package_name);
+    opts.download_tarball = url.resolve(opts.donwload_path,opts.package_name);
     return opts;
 };


### PR DESCRIPTION
https://github.com/mapbox/node-pre-gyp/issues/153

Add a property 'download_host' in binary object, and using the property when download tarball binaries.

The PR is Tested on my three module: [lwip-image](https://github.com/willerce/lwip-image),[lwip-decoder](https://github.com/willerce/lwip-decoder),[lwip-encoder](https://github.com/willerce/lwip-encoder)
