### PR TITLE
Support custom binary hosting mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Now you need to publish builds for all the platforms and node versions you wish 
 
 #### 8) You're done!
 
-Now publish your module to the npm registry. Users will now be able to install your module from a binary. 
+Now publish your module to the npm registry. Users will now be able to install your module from a binary.
 
 What will happen is this:
 
@@ -521,7 +521,7 @@ First, unlike the Travis linux machines the OS X machines do not put `node-pre-g
 export PATH=$(pwd)/node_modules/.bin:${PATH}
 ```
 
-Second, the OS X machines doe not support using a matrix for installing node.js different versions. So you need to bootstrap the installation of node.js in a cross platform way. 
+Second, the OS X machines doe not support using a matrix for installing node.js different versions. So you need to bootstrap the installation of node.js in a cross platform way.
 
 By doing:
 
@@ -579,3 +579,15 @@ The `binary` properties of `module_path`, `remote_path`, and `package_name` supp
 
 
 The options are visible in the code at <https://github.com/mapbox/node-pre-gyp/blob/612b7bca2604508d881e1187614870ba19a7f0c5/lib/util/versioning.js#L114-L127>
+
+# Download binary files from a mirror
+
+S3 is broken in China for the well known reason.
+
+Using the `npm` config argument: `--{module_name}_binary_host_mirror` can download binary files through a mirror.
+
+e.g.: Install [v8-profiler](https://www.npmjs.com/package/v8-profiler) from `npm`.
+
+```bash
+$ npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
+```

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -271,7 +271,11 @@ module.exports.evaluate = function(package_json,options) {
         module_main: package_json.main,
         toolset : options.toolset || '' // address https://github.com/mapbox/node-pre-gyp/issues/119
     };
-    opts.host = fix_slashes(eval_template(package_json.binary.host,opts));
+    // support host mirror with npm config `--{module_name}_binary_host_mirror`
+    // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
+    // > npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
+    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || package_json.binary.host;
+    opts.host = fix_slashes(eval_template(host,opts));
     opts.module_path = eval_template(package_json.binary.module_path,opts);
     // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably
     if (options.module_root) {

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -15,7 +15,7 @@ describe('versioning', function() {
                 "module_path" : "./lib/binding/{configuration}/{toolset}/{name}",
                 "remote_path" : "./{name}/v{version}/{configuration}/{version}/{toolset}/",
                 "package_name": "{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz",
-                "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"                
+                "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
             }
         };
         var opts = versioning.evaluate(mock_package_json, {});
@@ -62,6 +62,26 @@ describe('versioning', function() {
 
     it('should detect abi for node-webkit runtime', function() {
         assert.equal(versioning.get_runtime_abi('node-webkit','0.10.5'),versioning.get_node_webkit_abi('node-webkit','0.10.5'));
+    });
+
+    it('should detect custom binary host from env', function() {
+        var mock_package_json = {
+            "name"   : "test",
+            "main"   : "test.js",
+            "version": "0.1.0",
+            "binary" : {
+                "module_name" : "test",
+                "module_path" : "./lib/binding/{configuration}/{toolset}/{name}",
+                "remote_path" : "./{name}/v{version}/{configuration}/{version}/{toolset}/",
+                "package_name": "{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz",
+                "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
+            }
+        };
+        // mock npm_config_test_binary_host_mirror env
+        process.env.npm_config_test_binary_host_mirror = 'https://npm.taobao.org/mirrors/node-inspector/';
+        var opts = versioning.evaluate(mock_package_json, {});
+        assert.equal(opts.host,'https://npm.taobao.org/mirrors/node-inspector/');
+        delete process.env.npm_config_test_binary_host_mirror;
     });
 
 });


### PR DESCRIPTION
Like we setup a mirror site for node-inspector at
https://npm.taobao.org/mirrors/node-inspector/

These mirrors try to help people download binary files from China.

```bash
$ npm install node-inspector \
  --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
```