### PR TITLE
Recognize electron as a valid runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
   apt:
     sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5' ]
     # for testing node-webkit
-    packages: ['clang-3.5', 'xvfb','libasound2','libx11-6','libglib2.0-0','libgtk2.0-0','libatk1.0-0','libgdk-pixbuf2.0-0','libcairo2','libfreetype6','libfontconfig1','libxcomposite1','libasound2','libxdamage1','libxext6','libxfixes3','libnss3','libnspr4','libgconf-2-4','libexpat1','libdbus-1-3','libudev0']
+    packages: ['g++-4.8', 'xvfb','libasound2','libx11-6','libglib2.0-0','libgtk2.0-0','libatk1.0-0','libgdk-pixbuf2.0-0','libcairo2','libfreetype6','libfontconfig1','libxcomposite1','libasound2','libxdamage1','libxext6','libxfixes3','libnss3','libnspr4','libgconf-2-4','libexpat1','libdbus-1-3','libudev0']
 
 
 env:
@@ -28,8 +28,7 @@ env:
 
 before_install:
 - if [[ $(uname -s) == 'Linux' ]]; then
-     export CXX="clang++-3.5";
-     export CC="clang-3.5";
+     export CXX="g++-4.8";
   fi;
 - source ./scripts/install_node.sh ${NODE_VERSION}
 - npm config set loglevel=error

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Options include:
 
  - `-C/--directory`: run the command in this directory
  - `--build-from-source`: build from source instead of using pre-built binary
- - `--runtime=node-webkit`: customize the runtime: `node` and `node-webkit` are the valid options
+ - `--runtime=node-webkit`: customize the runtime: `node`, `electron` and `node-webkit` are the valid options
  - `--fallback-to-build`: fallback to building from source if pre-built binary is not available
  - `--target=0.10.25`: Pass the target node or node-webkit version to compile against
  - `--target_arch=ia32`: Pass the target arch and override the host `arch`. Valid values are 'ia32','x64', or `arm`.

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -17,6 +17,20 @@ if (process.env.NODE_PRE_GYP_ABI_CROSSWALK) {
     abi_crosswalk = require('./abi_crosswalk.json');
 }
 
+function get_electron_abi(runtime, target_version) {
+    if (!runtime) {
+        throw new Error("get_electron_abi requires valid runtime arg");
+    }
+    if (typeof target_version === 'undefined') {
+        // erroneous CLI call
+        throw new Error("Empty target version is not supported if electron is the target.");
+    }
+    // Electron guarentees that patch version update won't break native modules.
+    var sem_ver = semver.parse(target_version);
+    return runtime + '-v' + sem_ver.major + '.' + sem_ver.minor;
+}
+module.exports.get_electron_abi = get_electron_abi;
+
 function get_node_webkit_abi(runtime, target_version) {
     if (!runtime) {
         throw new Error("get_node_webkit_abi requires valid runtime arg");
@@ -55,6 +69,8 @@ function get_runtime_abi(runtime, target_version) {
     }
     if (runtime === 'node-webkit') {
         return get_node_webkit_abi(runtime, target_version || process.versions['node-webkit']);
+    } else if (runtime === 'electron') {
+        return get_electron_abi(runtime, target_version || process.versions.electron);
     } else {
         if (runtime != 'node') {
             throw new Error("Unknown Runtime: '" + runtime + "'");


### PR DESCRIPTION
This doesn't make node-pre-gyp fully support Electron, but this makes `node-pre-gyp install --fallback-to-build` work for Electron when `npm_config_runtime` is specified, so modules relying on node-pre-gyp can be compiled against Electron by building from source.

I'll try to add full support for Electron in other PRs.