### PR TITLE
skip validation for nw runtime

### DIFF
--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -20,6 +20,15 @@ function testbinary(gyp, argv, callback) {
     // ensure on windows that / are used for require path
     var binary_module = opts.module.replace(/\\/g, '/');
     var nw = (opts.runtime && opts.runtime === 'node-webkit');
+    if ((process.arch != opts.target_arch) ||
+        (process.platform != opts.target_platform)) {
+        var msg = "skipping validation since host platform/arch (";
+        msg += process.platform+'/'+process.arch+")";
+        msg += " does not match target (";
+        msg += opts.target_platform+'/'+opts.target_arch+")";
+        log.info('validate', msg);
+        return callback();
+    }
     if (nw) {
         options.timeout = 5000;
         if (process.platform === 'darwin') {
@@ -51,15 +60,6 @@ function testbinary(gyp, argv, callback) {
             return callback();
         });
         return;
-    }
-    if ((process.arch != opts.target_arch) ||
-        (process.platform != opts.target_platform)) {
-        var msg = "skipping validation since host platform/arch (";
-        msg += process.platform+'/'+process.arch+")";
-        msg += " does not match target (";
-        msg += opts.target_platform+'/'+opts.target_arch+")";
-        log.info('validate', msg);
-        return callback();
     }
     args.push('--eval');
     args.push("'require(\\'" + binary_module.replace(/\'/g, '\\\'') +"\\')'");


### PR DESCRIPTION
Preamble: I created simple package for tests [node-pre-gyp-tests](https://github.com/fleg/node-pre-gyp-tests), under ubuntu I try to install node-webkit win32 package, and got this error message:
```
fleg@home:~/js/node-pre-gyp-tests$ node-pre-gyp install --target=0.12.2 --target_platform=win32 --target_arch=ia32 --runtime=node-webkit
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.6.13
node-pre-gyp info using node@0.10.37 | linux | x64
node-pre-gyp info check checked for "/home/fleg/js/node-pre-gyp-tests/lib/binding/Release/node-webkit-v0.12.2-win32-ia32/TestPackage.node" (not found)
node-pre-gyp http GET https://flegdev.ru/node-pre-gyp-tests/TestPackage/TestPackage-v0.0.1-node-webkit-v0.12.2-win32-ia32.tar.gz
node-pre-gyp http 200 https://flegdev.ru/node-pre-gyp-tests/TestPackage/TestPackage-v0.0.1-node-webkit-v0.12.2-win32-ia32.tar.gz
node-pre-gyp info install unpacking TestPackage.node
node-pre-gyp info install unpacking node_addon_example.node
node-pre-gyp info tarball done parsing tarball
node-pre-gyp info validate Running test command: 'nw /home/fleg/js/node-pre-gyp-tests/node_modules/node-pre-gyp/lib/util/nw-pre-gyp /home/fleg/js/node-pre-gyp-tests/lib/binding/Release/node-webkit-v0.12.2-win32-ia32/TestPackage.node'
node-pre-gyp info stderr
node-pre-gyp ERR! install error
node-pre-gyp ERR! stack Error: spawn ENOENT
node-pre-gyp ERR! stack     at errnoException (child_process.js:1011:11)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:802:34)
node-pre-gyp ERR! System Linux 3.13.0-43-generic
node-pre-gyp ERR! command "node" "/home/fleg/js/node-pre-gyp-tests/node_modules/.bin/node-pre-gyp" "install" "--target=0.12.2" "--target_platform=win32" "--target_arch=ia32" "--runtime=node-webkit"
node-pre-gyp ERR! cwd /home/fleg/js/node-pre-gyp-tests
node-pre-gyp ERR! node -v v0.10.37
node-pre-gyp ERR! node-pre-gyp -v v0.6.13
node-pre-gyp ERR! not ok
spawn ENOENT
```
and when I install node win32 package, it works fine and skip validation:
```
fleg@home:~/js/node-pre-gyp-tests$ node-pre-gyp install --target_platform=win32 --target_arch=ia32
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.6.13
node-pre-gyp info using node@0.10.37 | linux | x64
node-pre-gyp info check checked for "/home/fleg/js/node-pre-gyp-tests/lib/binding/Release/node-v11-win32-ia32/TestPackage.node" (not found)
node-pre-gyp http GET https://flegdev.ru/node-pre-gyp-tests/TestPackage/TestPackage-v0.0.1-node-v11-win32-ia32.tar.gz
node-pre-gyp http 200 https://flegdev.ru/node-pre-gyp-tests/TestPackage/TestPackage-v0.0.1-node-v11-win32-ia32.tar.gz
node-pre-gyp info install unpacking TestPackage.node
node-pre-gyp info install unpacking node_addon_example.node
node-pre-gyp info tarball done parsing tarball
node-pre-gyp info validate skipping validation since host platform/arch (linux/x64) does not match target (win32/ia32)
[node-pre-gyp-tests] Success: "/home/fleg/js/node-pre-gyp-tests/lib/binding/Release/node-v11-win32-ia32/TestPackage.node" is installed via remote
node-pre-gyp info ok

```

So, this fix just skip validation like for node runtime