### PR TITLE
Detect the correct runtime when find() is called from Electron

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -241,6 +241,16 @@ function drop_double_slashes(pathname) {
     return pathname.replace(/\/\//g,'/');
 }
 
+function get_process_runtime() {
+    var runtime = 'node';
+    if (process.versions['node-webkit']) {
+        runtime = 'node-webkit';
+    } else if (process.versions.electron) {
+        runtime = 'electron';
+    }
+    return runtime;
+}
+
 var default_package_name = '{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz';
 var default_remote_path = '';
 
@@ -249,7 +259,7 @@ module.exports.evaluate = function(package_json,options) {
     validate_config(package_json);
     var v = package_json.version;
     var module_version = semver.parse(v);
-    var runtime = options.runtime || (process.versions['node-webkit'] ? 'node-webkit' : 'node');
+    var runtime = options.runtime || get_process_runtime();
     var opts = {
         name: package_json.name,
         configuration: Boolean(options.debug) ? 'Debug' : 'Release',


### PR DESCRIPTION
This fixes the case where require('node-pre-gyp').find() is called from Electron without explicitly specifying the runtime in the options. Previously the runtime would just default to "node" and find() would fail to find any native modules specifically built for Electron because `node-gyp` named the build output directory `{runtime}-v{version}-{platform}-{arch}`. For example after building a native module for Electron v0.34.2 the module binary ended up in the `electron-v0.34-win32-x64` directory, but find() was looking for it in the `node-v46-win32-x64` directory.