### PR TITLE
replaces find fn's reliance on deprecated fs.existsSync

### DIFF
--- a/lib/pre-binding.js
+++ b/lib/pre-binding.js
@@ -1,8 +1,17 @@
 "use strict";
 
 var versioning = require('../lib/util/versioning.js');
-var existsSync = require('fs').existsSync || require('path').existsSync;
+var fs = require('fs');
 var path = require('path');
+
+var fileExistsSync = function(file_path) {
+   try {
+      return fs.statSync(file_path).isFile();
+   }
+   catch (err) {
+      return false;
+   }
+};
 
 module.exports = exports;
 
@@ -13,7 +22,7 @@ exports.validate = function(package_json) {
 };
 
 exports.find = function(package_json_path,opts) {
-   if (!existsSync(package_json_path)) {
+   if (!fileExistsSync(package_json_path)) {
         throw new Error("package.json does not exist at " + package_json_path);
    }
    var package_json = require(package_json_path);


### PR DESCRIPTION
I can't find existsSync in path. I looked as far back as the 0.10.x docs. Also, existsSync is deprecated.

Therefore, I replaced it with fs.statSync which has been around at least since 0.10.x probably longer.