### PR TITLE
Add node-pre-gyp and npm versions to user agent

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -13,14 +13,26 @@ var versioning = require('./util/versioning.js');
 var testbinary = require('./testbinary.js');
 var clean = require('./clean.js');
 
+var npgVersion = 'unknown';
+try {
+    // Read own package.json to get the current node-pre-pyp version.
+    var ownPackageJSON = fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8');
+    npgVersion = JSON.parse(ownPackageJSON).version;
+} catch (e) {}
+
 function download(uri,opts,callback) {
     log.http('GET', uri);
 
     var req = null;
+
+    // Try getting version info from the currently running npm.
+    var envVersionInfo = process.env.npm_config_user_agent ||
+        'node ' + process.version;
+
     var requestOpts = {
         uri: uri.replace('+','%2B'),
         headers: {
-          'User-Agent': 'node-pre-gyp (node ' + process.version + ')'
+          'User-Agent': 'node-pre-gyp (v' + npgVersion + ', ' + envVersionInfo + ')'
         }
     };
 


### PR DESCRIPTION
Include the versions of node-pre-gyp and (if available) npm in the user agent.