### PR TITLE
Fixed spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
  - A command line tool called `node-pre-gyp` that can install your package's C++ module from a binary.
  - A variety of developer targeted commands for packaging, testing, and publishing binaries.
- - A Javascript module that can dynamically require your installed binary: `require('node-pre-gyp').find`
+ - A JavaScript module that can dynamically require your installed binary: `require('node-pre-gyp').find`
 
 For a hello world example of a module packaged with `node-pre-gyp` see <https://github.com/springmeyer/node-addon-example> and [the wiki ](https://github.com/mapbox/node-pre-gyp/wiki/Modules-using-node-pre-gyp) for real world examples.
 
@@ -145,9 +145,9 @@ It is highly recommended that you use Amazon S3. The reasons are:
   - S3 is a very solid hosting platform for distributing large files.
   - We provide detail documentation for using [S3 hosting](#s3-hosting) with node-pre-gyp.
 
-Why then not require S3? Because while some applications using node-pre-gyp need to distribute binaries as large as 20-30 MB, others might have very small binaries and might wish to store them in a github repo. This is not recommended, but if an author really wants to host in a non-s3 location then it should be possible.
+Why then not require S3? Because while some applications using node-pre-gyp need to distribute binaries as large as 20-30 MB, others might have very small binaries and might wish to store them in a GitHub repo. This is not recommended, but if an author really wants to host in a non-s3 location then it should be possible.
 
-It should also be mentioned that there is an optional and entirely seperate npm module called [node-pre-gyp-github](https://github.com/bchr02/node-pre-gyp-github) which is intended to complement node-pre-gyp and be installed along with it. It provides the ability to store and publish your binaries within your repositories GitHub Releases if you would rather not use S3 directly. Installation and usage instructions can be found [here](https://github.com/bchr02/node-pre-gyp-github), but the basic premise is that instead of using the ```node-pre-gyp publish``` command you would use ```node-pre-gyp-githib publish```.
+It should also be mentioned that there is an optional and entirely separate npm module called [node-pre-gyp-github](https://github.com/bchr02/node-pre-gyp-github) which is intended to complement node-pre-gyp and be installed along with it. It provides the ability to store and publish your binaries within your repositories GitHub Releases if you would rather not use S3 directly. Installation and usage instructions can be found [here](https://github.com/bchr02/node-pre-gyp-github), but the basic premise is that instead of using the ```node-pre-gyp publish``` command you would use ```node-pre-gyp-github publish```.
 
 ##### The `binary` object has two optional properties
 
@@ -371,15 +371,15 @@ Below is a guide to getting set up:
 
 #### 1) Create a free Appveyor account
 
-Go to https://ci.appveyor.com/signup/free and sign in with your github account.
+Go to https://ci.appveyor.com/signup/free and sign in with your GitHub account.
 
 #### 2) Create a new project
 
-Go to https://ci.appveyor.com/projects/new and select the github repo for your module
+Go to https://ci.appveyor.com/projects/new and select the GitHub repo for your module
 
 #### 3) Add appveyor.yml and push it
 
-Once you have committed an `appveyor.yml` ([appveyor.yml reference](http://www.appveyor.com/docs/appveyor-yml)) to your github repo and pushed it appveyor should automatically start building your project.
+Once you have committed an `appveyor.yml` ([appveyor.yml reference](http://www.appveyor.com/docs/appveyor-yml)) to your GitHub repo and pushed it AppVeyor should automatically start building your project.
 
 #### 4) Create secure variables
 
@@ -403,7 +403,7 @@ Just put `node-pre-gyp package publish` in your `appveyor.yml` after `npm instal
 
 #### 6) Publish when you want
 
-You might wish to publish binaries only on a specific commit. To do this you could borrow from the [Travis.ci idea of commit keywords](http://about.travis-ci.org/docs/user/how-to-skip-a-build/) and add special handling for commit messages with `[publish binary]`:
+You might wish to publish binaries only on a specific commit. To do this you could borrow from the [Travis CI idea of commit keywords](http://about.travis-ci.org/docs/user/how-to-skip-a-build/) and add special handling for commit messages with `[publish binary]`:
 
     SET CM=%APPVEYOR_REPO_COMMIT_MESSAGE%
     if not "%CM%" == "%CM:[publish binary]=%" node-pre-gyp --msvs_version=2013 publish
@@ -457,7 +457,7 @@ Just put `node-pre-gyp package publish` in your `.travis.yml` after `npm install
 
 ##### OS X publishing
 
-If you want binaries for OS X in addition to linux you can enable [multi-os for travis](http://docs.travis-ci.com/user/multi-os/#Setting-.travis.yml)
+If you want binaries for OS X in addition to linux you can enable [multi-os for Travis](http://docs.travis-ci.com/user/multi-os/#Setting-.travis.yml)
 
 Use a configuration like:
 
@@ -481,7 +481,7 @@ before_install:
 - nvm use $NODE_VERSION
 ```
 
-See [Travis OS X Gochas](#travis-os-x-gochas) for why we replace `language: node_js` and `node_js:` sections with `language: cpp` and a custom matrix.
+See [Travis OS X Gotchas](#travis-os-x-gotchas) for why we replace `language: node_js` and `node_js:` sections with `language: cpp` and a custom matrix.
 
 Also create platform specific sections for any deps that need install. For example if you need libpng:
 
@@ -492,15 +492,15 @@ Also create platform specific sections for any deps that need install. For examp
 
 For detailed multi-OS examples see [node-mapnik](https://github.com/mapnik/node-mapnik/blob/master/.travis.yml) and [node-sqlite3](https://github.com/mapbox/node-sqlite3/blob/master/.travis.yml).
 
-##### Travis OS X Gochas
+##### Travis OS X Gotchas
 
-First, unlike the Travis linux machines the OS X machines do not put `node-pre-gyp` on PATH by default. So to you will need to:
+First, unlike the Travis Linux machines, the OS X machines do not put `node-pre-gyp` on PATH by default. To do so you will need to:
 
 ```sh
 export PATH=$(pwd)/node_modules/.bin:${PATH}
 ```
 
-Second, the OS X machines do not support using a matrix for installing different node.js versions. So you need to bootstrap the installation of node.js in a cross platform way.
+Second, the OS X machines do not support using a matrix for installing different Node.js versions. So you need to bootstrap the installation of Node.js in a cross platform way.
 
 By doing:
 
@@ -527,7 +527,7 @@ node_js:
 
 #### 4) Publish when you want
 
-You might wish to publish binaries only on a specific commit. To do this you could borrow from the [Travis.ci idea of commit keywords](http://about.travis-ci.org/docs/user/how-to-skip-a-build/) and add special handling for commit messages with `[publish binary]`:
+You might wish to publish binaries only on a specific commit. To do this you could borrow from the [Travis CI idea of commit keywords](http://about.travis-ci.org/docs/user/how-to-skip-a-build/) and add special handling for commit messages with `[publish binary]`:
 
     COMMIT_MESSAGE=$(git log --format=%B --no-merges -n 1 | tr -d '\n')
     if [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then node-pre-gyp publish; fi;
@@ -540,7 +540,7 @@ Or, if you don't have any changes to make simply run:
 
     git commit --allow-empty -m "[publish binary]"
 
-WARNING: if you are working in a pull request and publishing binaries from there then you will want to avoid double publishing when Travis.ci builds both the `push` and `pr`. You only want to run the publish on the `push` commit. See https://github.com/Project-OSRM/node-osrm/blob/8eb837abe2e2e30e595093d16e5354bc5c573575/scripts/is_pr_merge.sh which is called from https://github.com/Project-OSRM/node-osrm/blob/8eb837abe2e2e30e595093d16e5354bc5c573575/scripts/publish.sh for an example of how to do this.
+WARNING: if you are working in a pull request and publishing binaries from there then you will want to avoid double publishing when Travis CI builds both the `push` and `pr`. You only want to run the publish on the `push` commit. See https://github.com/Project-OSRM/node-osrm/blob/8eb837abe2e2e30e595093d16e5354bc5c573575/scripts/is_pr_merge.sh which is called from https://github.com/Project-OSRM/node-osrm/blob/8eb837abe2e2e30e595093d16e5354bc5c573575/scripts/publish.sh for an example of how to do this.
 
 Remember this publishing is not the same as `npm publish`. We're just talking about the binary module here and not your entire npm package. To automate the publishing of your entire package to npm on Travis see http://about.travis-ci.org/docs/user/deployment/npm/
 

--- a/test/app1/README.md
+++ b/test/app1/README.md
@@ -1,3 +1,3 @@
 # Test app
 
-Demostrates a simple configuration that uses node-pre-gyp.
+Demonstrates a simple configuration that uses node-pre-gyp.

--- a/test/app2/README.md
+++ b/test/app2/README.md
@@ -1,3 +1,3 @@
 # Test app
 
-Demostrates a very custom situation where an option must be passed to node-gyp in order for the binding.gyp to be properly configured.
+Demonstrates a very custom situation where an option must be passed to node-gyp in order for the binding.gyp to be properly configured.

--- a/test/app3/README.md
+++ b/test/app3/README.md
@@ -1,7 +1,5 @@
 # Test app
 
-Demostrates an example node c++ app that depends on an external static library.
+Demonstrates an example Node.js C++ app that depends on an external static library.
 
 Because the external `mylib.a` library is statically built and linked it will be available inside the `app3.node` binary. See the `app4` example for how to handle shared libraries.
-
-Demostrates an example node c++ app that depends on an external library.

--- a/test/app3/deps/README.md
+++ b/test/app3/deps/README.md
@@ -1,4 +1,3 @@
-# sample c++ libary
+# sample C++ library
 
 Example based on https://github.com/springmeyer/hello-gyp
-

--- a/test/app4/README.md
+++ b/test/app4/README.md
@@ -1,6 +1,6 @@
 # Test app
 
-Demostrates an example node c++ app that depends on an external shared library.
+Demonstrates an example Node.js C++ app that depends on an external shared library.
 
 See the `app3` example for how to handle static libraries.
 

--- a/test/app4/deps/README.md
+++ b/test/app4/deps/README.md
@@ -1,4 +1,3 @@
-# sample c++ libary
+# Sample C++ library
 
 Example based on https://github.com/springmeyer/hello-gyp
-


### PR DESCRIPTION
- Fixed 3 "gocha" misspellings.
- Fixed 5 "demostrates" misspellings.
- Fixed 2 "libary" misspellings.
- Fixed "node-pre-gyp-gith**i**b" misspelling.
- Removed a duplicate sentence in `test/app3/README.md`.
- Standardized spelling and capital letter usage for the following names:
  - Node.js
  - GitHub
  - C++
  - AppVeyor
  - Travis CI
  - JavaScript
