### PR TITLE
Honor npm configuration for CA bundles

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -36,6 +36,16 @@ function download(uri,opts,callback) {
         }
     };
 
+    if (opts.cafile) {
+        try {
+            requestOpts.ca = fs.readFileSync(opts.cafile);
+        } catch (e) {
+            return callback(e);
+        }
+    } else if (opts.ca) {
+        requestOpts.ca = opts.ca;
+    }
+
     var proxyUrl = opts.proxy ||
                     process.env.http_proxy ||
                     process.env.HTTP_PROXY ||
@@ -159,6 +169,10 @@ function install(gyp, argv, callback) {
         } catch (err) {
             return callback(err);
         }
+
+        opts.ca = gyp.opts.ca;
+        opts.cafile = gyp.opts.cafile;
+
         var from = opts.hosted_tarball;
         var to = opts.module_path;
         var binary_module = path.join(to,opts.module_name + '.node');


### PR DESCRIPTION
Pass ‘ca’ and ‘cafile’ values from npm config options to request() when downloading binaries to honor a user-specified SSL CA. Allows using node-pre-gyp on environments with custom CAs.