### PR TITLE
Switch to got for file downloading

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -12,6 +12,10 @@ var existsAsync = fs.exists || path.exists;
 var versioning = require('./util/versioning.js');
 var testbinary = require('./testbinary.js');
 var clean = require('./clean.js');
+var got = require('got');
+var tar = require('tar');
+var url = require('url');
+var tunnel = require('tunnel');
 
 var npgVersion = 'unknown';
 try {
@@ -20,7 +24,49 @@ try {
     npgVersion = JSON.parse(ownPackageJSON).version;
 } catch (e) {}
 
-function download(uri,opts,callback) {
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function setupProxy(uri, requestOpts, opts) {
+    var proxyURL = opts.proxy ||
+                    process.env.http_proxy ||
+                    process.env.HTTP_PROXY ||
+                    process.env.npm_config_proxy;
+    if (!proxyURL) {
+        return;
+    }
+    var proxy;
+    try {
+        proxy = url.parse(proxyURL);
+    } catch (e) {
+        log.warn('download', 'ignoring invalid "proxy" url setting cannot parse: "%s"\n%s', proxyURL, e);
+        return;
+    }
+
+    var proxyProtocol = (proxy.protocol || "").slice(0, -1);
+
+    // I'm going to assume a valid download url at this point
+    var downloadProtocol = url.parse(uri).protocol.slice(0, -1);
+
+    if ('http' !== proxyProtocol && 'https' !== proxyProtocol) {
+      log.warn('download', 'ignoring invalid "proxy" url setting requires http or https: "%s" "%s"', proxy.protocol, proxy.href);
+      return;
+    }
+
+    log.verbose('download', 'using proxy url: "%s"', proxy.href);
+    var tunnelName = downloadProtocol + "Over" + capitalizeFirstLetter(proxyProtocol);
+    var agent = tunnel[tunnelName]({
+        proxy: {
+            host:      proxy.hostname,
+            port:      proxy.port,
+            proxyAuth: proxy.auth
+        }
+    });
+    requestOpts.agent = agent;
+}
+
+function download(uri, opts, callback) {
     log.http('GET', uri);
 
     var req = null;
@@ -29,35 +75,19 @@ function download(uri,opts,callback) {
     var envVersionInfo = process.env.npm_config_user_agent ||
         'node ' + process.version;
 
+    var uri = uri.replace('+','%2B');
     var requestOpts = {
-        uri: uri.replace('+','%2B'),
         headers: {
           'User-Agent': 'node-pre-gyp (v' + npgVersion + ', ' + envVersionInfo + ')'
-        }
+        },
+        retries: 2
     };
+    setupProxy(uri, requestOpts, opts);
 
-    var proxyUrl = opts.proxy ||
-                    process.env.http_proxy ||
-                    process.env.HTTP_PROXY ||
-                    process.env.npm_config_proxy;
-    if (proxyUrl) {
-      if (/^https?:\/\//i.test(proxyUrl)) {
-        log.verbose('download', 'using proxy url: "%s"', proxyUrl);
-        requestOpts.proxy = proxyUrl;
-      } else {
-        log.warn('download', 'ignoring invalid "proxy" config setting: "%s"', proxyUrl);
-      }
-    }
-    try {
-        req = require('request')(requestOpts);
-    } catch (e) {
-        return callback(e);
-    }
-    if (req) {
-      req.on('response', function (res) {
-        log.http(res.statusCode, uri);
-      });
-    }
+    req = got.stream(uri, requestOpts);
+    req.on('response', function (res) {
+      log.http(res.statusCode, uri);
+    });
     return callback(null,req);
 }
 
@@ -68,7 +98,7 @@ function place_binary(from,to,opts,callback) {
         var badDownload = false;
         var extractCount = 0;
         var gunzip = zlib.createGunzip();
-        var extracter = require('tar').Extract({ path: to, strip: 1});
+        var extracter = tar.Extract({ path: to, strip: 1});
 
         function afterTarball(err) {
             if (err) return callback(err);
@@ -127,7 +157,7 @@ function print_fallback_error(err,opts,package_json) {
     var full_message = "Pre-built binaries not found for " + package_json.name + "@" + package_json.version;
     full_message += " and " + opts.runtime + "@" + (opts.target || process.versions.node) + " (" + opts.node_abi + " ABI)";
     full_message += fallback_message;
-    log.error("Tried to download(" + err.statusCode + "): " + opts.hosted_tarball);
+    log.error("Tried to download(" + (err.statusCode || err.message) + "): " + opts.hosted_tarball);
     log.error(full_message);
     log.http(err.message);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-pre-gyp",
   "description": "Node.js native addon binary install tool",
-  "version" : "0.6.31",
+  "version": "0.6.31",
   "keywords": [
     "native",
     "addon",
@@ -20,15 +20,16 @@
   "bin": "./bin/node-pre-gyp",
   "main": "./lib/node-pre-gyp.js",
   "dependencies": {
+    "got": "^6.5.0",
     "mkdirp": "~0.5.1",
     "nopt": "~3.0.6",
     "npmlog": "^4.0.0",
     "rc": "~1.1.6",
-    "request": "^2.75.0",
     "rimraf": "~2.5.4",
     "semver": "~5.3.0",
     "tar": "~2.2.1",
-    "tar-pack": "~3.3.0"
+    "tar-pack": "~3.3.0",
+    "tunnel": "0.0.4"
   },
   "devDependencies": {
     "aws-sdk": "2.x",


### PR DESCRIPTION
Closes #198

- I haven't smoke tested the happy paths for proxy downloading. 
- I have tested direct downloading over https.

Even though got requires node 4+ I stuck to es5 to match convention in the project.