### PR TITLE
update request to allow for strictSSL = false

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -55,7 +55,7 @@ function download(uri,opts,callback) {
         log.verbose('download', 'using proxy url: "%s"', proxyUrl);
         requestOpts.proxy = proxyUrl;
         requestOpts.strictSSL = opts.strictSSL ||
-                    process.env.strictSSL
+                    process.env.strictSSL;
       } else {
         log.warn('download', 'ignoring invalid "proxy" config setting: "%s"', proxyUrl);
       }

--- a/lib/install.js
+++ b/lib/install.js
@@ -54,6 +54,8 @@ function download(uri,opts,callback) {
       if (/^https?:\/\//i.test(proxyUrl)) {
         log.verbose('download', 'using proxy url: "%s"', proxyUrl);
         requestOpts.proxy = proxyUrl;
+        requestOpts.strictSSL = opts.strictSSL ||
+                    process.env.strictSSL
       } else {
         log.warn('download', 'ignoring invalid "proxy" config setting: "%s"', proxyUrl);
       }


### PR DESCRIPTION
By allowing the env variable strictSSL = false to be included in the install request, it makes it easier for users behind a proxy to use this application.  The default for Request is true if the variable is undefined in the Opts object, so the above change would allow a user to override the default if desired. Other env variable formats could be included.