### PR TITLE
Include package.json instead of just package

### DIFF
--- a/lib/node-pre-gyp.js
+++ b/lib/node-pre-gyp.js
@@ -59,7 +59,7 @@ var proto = Run.prototype;
  * Export the contents of the package.json.
  */
 
-proto.package = require('../package');
+proto.package = require('../package.json');
 
 /**
  * nopt configuration definitions


### PR DESCRIPTION
This probably seems unnecessary, but tools like Rollup that do transforms based on file extension choke when trying to understand loading a JSON file without an extension specified. This is stopping me from using libraries which depend on node-pre-gyp in my build process.