### PR TITLE
Allow electron process forks of modules that use pre-gyp

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -263,7 +263,8 @@ function get_process_runtime(versions) {
     var runtime = 'node';
     if (versions['node-webkit']) {
         runtime = 'node-webkit';
-    } else if (versions.electron) {
+    } else if (versions.electron || process.env.ELECTRON_RUN_AS_NODE) {
+        // Running in electron or a childProcess.fork of electron
         runtime = 'electron';
     }
     return runtime;

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -77,6 +77,12 @@ test('should detect runtime for node-webkit and electron', function(t) {
         "node-webkit": '0.37.3',
     };
     t.equal(versioning.get_process_runtime(mock_process_versions3),'node-webkit');
+    var mock_process_versions4 = {
+        "node": '0.8.0',
+    };
+    process.env.ELECTRON_RUN_AS_NODE = 1;
+    t.equal(versioning.get_process_runtime(mock_process_versions4), 'electron');
+    delete process.env.ELECTRON_RUN_AS_NODE;
     t.end();
 });
 


### PR DESCRIPTION
closes https://github.com/mapbox/node-pre-gyp/issues/278

I still need to check to see if this works in built electron apps, but this is fairly close to solving the issue of allowing `childProcess.fork`s in electron of node-pre-gyp modules.