### PR TITLE
Do actually test the binaries

### DIFF
--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -62,7 +62,7 @@ function testbinary(gyp, argv, callback) {
         return;
     }
     args.push('--eval');
-    args.push("'require(\\'" + binary_module.replace(/\'/g, '\\\'') +"\\')'");
+    args.push("require('" + binary_module.replace(/'/g, '\'') +"')");
     log.info("validate","Running test command: '" + shell_cmd + ' ' + args.join(' ') + "'");
     cp.execFile(shell_cmd, args, options, function(err, stdout, stderr) {
         if (err) {


### PR DESCRIPTION
The second argument has too much quotes so it is passed to node as string, meaning that nothing is actually tested.