### PR TITLE
Remove use of prepublish in recommended setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ This looks like:
     }
     "bundledDependencies":["node-pre-gyp"],
     "scripts": {
-        "prepublish": "npm ls",
         "install": "node-pre-gyp install --fallback-to-build"
     },
     "binary": {


### PR DESCRIPTION
The recommendation of `prepublish` here was to help ensure the bundled deps tree is correct before publishing (because sadly npm does not do this for us: https://github.com/npm/npm/issues/5929).

But `prepublish` also runs during install per https://github.com/npm/npm/issues/10074 and https://github.com/npm/npm/blob/latest/CHANGELOG.md#new-prepare-script-prepublish-deprecated-breaking. So, let's avoid the confusion and potential gochas of different npm versions by not recommending this hook.

refs https://github.com/springmeyer/bundle-dedupe-testcase a testcase demonstrated a problem with `npm ls` triggering an error on `npm install` due to a deduping bug in npm v3.x