### PR TITLE
Search path for npm to use npm's node-gyp

### DIFF
--- a/lib/util/compile.js
+++ b/lib/util/compile.js
@@ -52,6 +52,14 @@ function which_node_gyp() {
     if (existsSync(node_gyp_bin)) {
         return node_gyp_bin;
     }
+
+    try {
+        var maybe_elsewhere = path.join(path.dirname(fs.realpathSync(which('npm'))), 
+                                    '..', 'node_modules/node-gyp/bin/node-gyp.js');
+        if (existsSync(maybe_elsewhere)) {
+            return maybe_elsewhere;
+        }
+    } catch (err) { }
 }
 
 module.exports.run_gyp = function(args,opts,callback) {

--- a/lib/util/compile.js
+++ b/lib/util/compile.js
@@ -4,6 +4,7 @@ module.exports = exports;
 
 var fs = require('fs');
 var path = require('path');
+var which = require('which').sync;
 var win = process.platform == 'win32';
 var existsSync = fs.existsSync || path.existsSync;
 var cp = require('child_process');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
     "tar": "^2.2.1",
-    "tar-pack": "^3.4.0"
+    "tar-pack": "^3.4.0",
+    "which": "^1.2.14"
   },
   "devDependencies": {
     "aws-sdk": "^2.28.0",


### PR DESCRIPTION
This fixes issues during weird rebuild scenarios when installing with yarn and rebuilding for electron using electron-builder.

The fix is fairly general though, as it will search the users path for npm, then resolve the node-gyp that it ships.  If npm doesn't exist, it will noop.

I'm not really sure how to test this, other than locally, since its such an environmental codepath.

Related to: https://github.com/yarnpkg/yarn/pull/3240 
and https://github.com/electron-userland/electron-builder/issues/1542
