### PR TITLE
Refactor tests / port to tape

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,16 +17,15 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
   - npm config get
-  # make node >= 4.x x86 builds work
-  # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  #- IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g cafile=package.json
-  #- IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
+  # upgrade node-gyp to dodge https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-307641388
+  # and allow make node 4.x x86 builds work
+  # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
   - IF "%nodejs_version:~0,1%"=="4" npm install node-gyp@3.x
   # downgrade npm to avoid multiple npm bugs:
-  # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
+  # for node v6/v8 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
   # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233
   - npm install npm@2.x -g
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
   - npm config get
+  - npm config ls -l
   # make node@4.x x86 builds work
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
   #- npm config set -g cafile=package.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,9 @@ install:
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
   - IF "%nodejs_version:~0,1%"=="4" npm install node-gyp@3.x
   # downgrade npm to avoid multiple npm bugs:
-  # for node v6/v8 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
+  # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
   # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233
+  # for node v8 this dodges https://github.com/mapbox/node-pre-gyp/issues/302
   - npm install npm@2.x -g
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: 0.10
     - nodejs_version: 4
     - nodejs_version: 6
+    - nodejs_version: 8
 
 platform:
   - x64
@@ -16,18 +17,14 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
   - npm config get
-  - npm config ls -l
-  # make node@4.x x86 builds work
-  # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  #- npm config set -g cafile=package.json
-  #- npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
-  - npm install node-gyp@3.x
-  - npm install npm@2.x -g
+  - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
+  # downgrade npm with node v6 to dodge npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp
+  - IF "%nodejs_version:~0,1%"=="6" npm install npm@2.x -g
   - node --version
   - npm --version
-  - node -e "console.log(process.arch,process.env.node_pre_gyp_accessKeyId);"
+  - node -e "console.log(process.arch);"
   - IF /I "%PLATFORM%" == "x64" set PATH=C:\Python27-x64;%PATH%
   - IF /I "%PLATFORM%" == "x86" SET PATH=C:\python27;%PATH%
   - IF /I "%PLATFORM%" == "x64" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - npm install node-gyp@3.x
+  - npm install npm@2.x -g
   - node --version
   - npm --version
   - node -e "console.log(process.arch,process.env.node_pre_gyp_accessKeyId);"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,16 +15,17 @@ shallow_clone: true
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
+  - npm config get
   # make node@4.x x86 builds work
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  - npm config set -g cafile=package.json
-  - npm config set -g strict-ssl=false
+  #- npm config set -g cafile=package.json
+  #- npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - npm install node-gyp@3.x
   - node --version
   - npm --version
-  - node -e "console.log(process.arch);"
+  - node -e "console.log(process.arch,process.env.node_pre_gyp_accessKeyId);"
   - IF /I "%PLATFORM%" == "x64" set PATH=C:\Python27-x64;%PATH%
   - IF /I "%PLATFORM%" == "x86" SET PATH=C:\python27;%PATH%
   - IF /I "%PLATFORM%" == "x64" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,11 +19,12 @@ install:
   - npm config get
   # make node >= 4.x x86 builds work
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  - IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g cafile=package.json
-  - IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g strict-ssl=false
+  #- IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g cafile=package.json
+  #- IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
+  - IF "%nodejs_version:~0,1%"=="4" npm install node-gyp@3.x
   # downgrade npm to avoid multiple npm bugs:
   # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
   # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ install:
   # downgrade npm to avoid multiple npm bugs:
   # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
   # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233
-  - node --version
+  # for node v8 this dodges https://github.com/mapbox/node-pre-gyp/issues/302
+  - npm install npm@2.x -g  - node --version
   - npm --version
   - node -e "console.log(process.arch);"
   - IF /I "%PLATFORM%" == "x64" set PATH=C:\Python27-x64;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,15 @@ install:
   - npm config get
   # make node >= 4.x x86 builds work
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  - IF /I "%PLATFORM%" == "x86" npm config set -g cafile=package.json
-  - IF /I "%PLATFORM%" == "x86" npm config set -g strict-ssl=false
+  #- IF /I "%PLATFORM%" == "x86" npm config set -g cafile=package.json
+  #- IF /I "%PLATFORM%" == "x86" npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
   # downgrade npm with node v6 to dodge npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp
   # https://github.com/mapbox/node-pre-gyp/issues/300
-  - IF "%nodejs_version:~0,1%"=="6" npm install npm@2.x -g
+  #- IF "%nodejs_version:~0,1%"=="6" npm install npm@2.x -g
+  - npm install npm@2.x -g
   - node --version
   - npm --version
   - node -e "console.log(process.arch);"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,6 @@ install:
   # downgrade npm to avoid multiple npm bugs:
   # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
   # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233
-  # for node v8 this dodges https://github.com/mapbox/node-pre-gyp/issues/302
-  - npm install npm@2.x -g
   - node --version
   - npm --version
   - node -e "console.log(process.arch);"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ install:
   - npm config get
   # make node >= 4.x x86 builds work
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  #- IF /I "%PLATFORM%" == "x86" npm config set -g cafile=package.json
-  #- IF /I "%PLATFORM%" == "x86" npm config set -g strict-ssl=false
+  - IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g cafile=package.json
+  - IF /I "%PLATFORM%" == "x86" IF "%nodejs_version:~0,1%"=="4" npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
-  # downgrade npm with node v6 to dodge npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp
-  # https://github.com/mapbox/node-pre-gyp/issues/300
-  #- IF "%nodejs_version:~0,1%"=="6" npm install npm@2.x -g
+  # downgrade npm to avoid multiple npm bugs:
+  # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
+  # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233
   - npm install npm@2.x -g
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,15 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
   - npm config get
+  # make node >= 4.x x86 builds work
+  # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
+  - IF /I "%PLATFORM%" == "x86" npm config set -g cafile=package.json
+  - IF /I "%PLATFORM%" == "x86" npm config set -g strict-ssl=false
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
   - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
   # downgrade npm with node v6 to dodge npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp
+  # https://github.com/mapbox/node-pre-gyp/issues/300
   - IF "%nodejs_version:~0,1%"=="6" npm install npm@2.x -g
   - node --version
   - npm --version

--- a/bin/node-pre-gyp
+++ b/bin/node-pre-gyp
@@ -26,10 +26,13 @@ prog.parseArgv(process.argv);
 if (prog.todo.length === 0) {
   if (~process.argv.indexOf('-v') || ~process.argv.indexOf('--version')) {
     console.log('v%s', prog.version);
-  } else {
+    return process.exit(0);
+  } else if (~process.argv.indexOf('-h') || ~process.argv.indexOf('--help')) {
     console.log('%s', prog.usage());
+    return process.exit(0);
   }
-  return process.exit(0);
+  console.log('%s', prog.usage());
+  return process.exit(1);
 }
 
 // if --no-color is passed

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -17,6 +17,14 @@ if (process.env.NODE_PRE_GYP_ABI_CROSSWALK) {
     abi_crosswalk = require('./abi_crosswalk.json');
 }
 
+var major_versions = {};
+Object.keys(abi_crosswalk).forEach(function(v) {
+    var major = v.split('.')[0];
+    if (!major_versions[major]) {
+        major_versions[major] = v;
+    }
+});
+
 function get_electron_abi(runtime, target_version) {
     if (!runtime) {
         throw new Error("get_electron_abi requires valid runtime arg");
@@ -135,6 +143,13 @@ function get_runtime_abi(runtime, target_version) {
                         if (minor === 0 && patch === 0) {
                             break;
                         }
+                    }
+                } else if (major >= 2) {
+                    // look for last release that is the same major version
+                    if (major_versions[major]) {
+                        cross_obj = abi_crosswalk[major_versions[major]];
+                        console.log('Warning: node-pre-gyp could not find exact match for ' + target_version);
+                        console.log('Warning: but node-pre-gyp successfully choose ' + major_versions[major] + ' as ABI compatible target');
                     }
                 } else if (major === 0) { // node.js
                     if (target_parts[1] % 2 === 0) { // for stable/even node.js series

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "request": "^2.81.0",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
+    "tape": "^4.6.3",
     "tar": "^2.2.1",
     "tar-pack": "^3.4.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.28.0",
-    "mocha": "^3.2.0",
     "retire": "^1.2.12",
     "jshint": "^2.9.4"
   },
@@ -40,13 +40,12 @@
     "node": true,
     "globalstrict": true,
     "undef": true,
-    "unused": true,
-    "noarg": true,
-    "mocha": true
+    "unused": false,
+    "noarg": true
   },
   "scripts": {
     "pretest": "jshint test/build.test.js test/s3_setup.test.js test/versioning.test.js",
     "update-crosswalk": "node scripts/abi_crosswalk.js",
-    "test": "jshint lib lib/util scripts bin/node-pre-gyp && mocha -R spec --timeout 500000"
+    "test": "jshint lib lib/util scripts bin/node-pre-gyp && tape test/*test.js"
   }
 }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -66,23 +66,22 @@ test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, functio
 });
 
 // TODO - for some reason these do not error on windows
-if (process.platform !== 'win32') {
-    test(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(t) {
-        run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
-            t.ok(err, 'Expected command to fail');
-            t.stringContains(stderr,"Can't find Python executable");
-            t.end();
-        });
+test(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+    run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
+        t.ok(err, 'Expected command to fail');
+        t.stringContains(stderr,"Can't find Python executable");
+        t.end();
     });
+});
 
-    test(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(t) {
-        run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
-            t.ok(err, 'Expected command to fail');
-            t.stringContains(stderr,"Can't find Python executable");
-            t.end();
-        });
+test(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(t) {
+    run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
+        t.ok(err, 'Expected command to fail');
+        t.stringContains(stderr,"Can't find Python executable");
+        t.end();
     });
-}
+});
+
 // note: --ensure=false tells node-gyp to attempt to re-download the node headers
 // even if they already exist on disk at ~/.node-gyp/{version}
 test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(t) {

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require('assert');
+var test = require('tape');
 var cp = require('child_process');
 var path = require('path');
 var existsSync = require('fs').existsSync || require('path').existsSync;
@@ -32,9 +32,10 @@ function run(prog,command,args,app,opts,cb) {
     }
     final_cmd += ' ' + app.args;
     final_cmd += ' ' + args;
-    cp.exec(final_cmd,opts,function(err,stdout,stderr) {
+    cp.exec('V=1 '+final_cmd,opts,function(err,stdout,stderr) {
         if (err) {
-            var error = new Error("Command failed '" + command + "'");
+            var error = new Error("Command failed '" + final_cmd + "'");
+            error.stack = stderr;
             return cb(error,stdout,stderr);
         }
         return cb(err,stdout,stderr);
@@ -64,14 +65,6 @@ var apps = [
     }
 ];
 
-function detectIOJS(current_version) {
-    var current_parts = current_version.split('.').map(function(i) { return +i; });
-    if (current_parts[0] == 1) return true;
-    return false;
-}
-
-var is_iojs = detectIOJS(process.version.replace('v',''));
-
 function getPreviousVersion(current_version) {
     var current_parts = current_version.split('.').map(function(i) { return +i; });
     var major = current_parts[0];
@@ -91,13 +84,6 @@ function getPreviousVersion(current_version) {
     return undefined;
 }
 
-function on_error(err,stdout,stderr) {
-    var msg = err.message;
-    msg += '\nstdout: ' + stdout;
-    msg += '\nstderr: ' + stderr;
-    throw new Error(msg);
-}
-
 var current_version = process.version.replace('v','');
 var previous_version = getPreviousVersion(current_version);
 var target_abi;
@@ -109,398 +95,264 @@ if (previous_version !== undefined && previous_version !== current_version) {
     fs.writeFileSync(testing_crosswalk,JSON.stringify(target_abi));
 }
 
-describe('simple build and test', function() {
+// https://stackoverflow.com/questions/38599457/how-to-write-a-custom-assertion-for-testing-node-or-javascript-with-tape-or-che
+test.Test.prototype.stringContains = function(actual, contents, message) {
+  this._assert(actual.indexOf(contents) > -1, {
+    message: message || 'should contain '+contents,
+    operator: 'stringContains',
+    actual: actual,
+    expected: contents
+  });
+};
 
-    var app = {"name": "app2", "args":'--custom_include_path=../include --toolset=cpp11'};
+apps.forEach(function(app) {
 
-    before(function(done) {
         // clear out entire binding directory
         // to ensure no stale builds. This is needed
         // because "node-pre-gyp clean" only removes
         // the current target and not alternative builds
-        var binding_directory = path.join(__dirname,app.name,'lib/binding');
-        if (fs.existsSync(binding_directory)) {
-            rm(binding_directory,done);
-        } else {
-            done();
-        }
-    });
-
-    it(app.name + ' rebuilds ' + app.args, function(done) {
-        run('node-pre-gyp', 'rebuild', '--loglevel=error', app, {}, function(err,stdout,stderr) {
-            if (err) return on_error(err,stdout,stderr);
-            if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                assert.equal(stderr,'');
+        test('cleanup of app', function(t) {
+            var binding_directory = path.join(__dirname,app.name,'lib/binding');
+            if (fs.existsSync(binding_directory)) {
+                rm.sync(binding_directory);
             }
-            done();
+            t.end();
         });
-    });
 
-    it(app.name + ' passes tests ' + app.args, function(done) {
-        // work around https://github.com/iojs/io.js/issues/751
-        if (is_iojs && process.platform === 'win32') {
-            run('iojs','index.js','', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                if (err) return on_error(err,stdout,stderr);
-                assert.equal(stderr,'');
-                // we expect app2 to console.log on success
-                if (app.name == 'app2') {
-                    if (app.args.indexOf('--debug') > -1) {
-                        assert.ok(stdout.indexOf('Loaded Debug build') > -1);
-                    } else {
-                        assert.ok(stdout.indexOf('Loaded Release build') > -1);
-                    }
-                } else {
-                    assert.equal(stdout,'');
-                }
-                done();
+        test(app.name + ' configures ' + app.args, function(t) {
+            run('node-pre-gyp', 'configure', '--loglevel=error', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.end();
             });
-        } else {
-            run('npm','test','', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                if (err) return on_error(err,stdout,stderr);
-                if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                    assert.equal(stderr,'');
+        });
+
+        test(app.name + ' configures with unparsed options ' + app.args, function(t) {
+            run('node-pre-gyp', 'configure', '--loglevel=info -- -Dfoo=bar', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.ok(stderr.search(/(gyp info spawn args).*(-Dfoo=bar)/) > -1);
+                t.end();
+            });
+        });
+
+        test(app.name + ' installs', function(t) {
+            run('node-pre-gyp', 'install', '--update-binary --fallback-to-build', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.stringContains(stdout,'Success: ');
+                t.end();
+            });
+        });
+
+        test(app.name + ' builds ' + app.args, function(t) {
+            run('node-pre-gyp', 'rebuild', '--fallback-to-build --loglevel=error', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                if (app.args.indexOf('--debug') > -1) {
+                    t.stringContains(stdout,'Debug/'+app.name+'.node');
+                } else {
+                    t.stringContains(stdout,'Release/'+app.name+'.node');
                 }
+                t.end();
+            });
+        });
+
+        test(app.name + ' is found ' + app.args, function(t) {
+            run('node-pre-gyp', 'reveal', 'module_path --silent', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                var module_path = stdout.trim();
+                t.ok(module_path.search(app.name) > -1);
+                t.ok(existsSync(module_path),'is found '+ module_path);
+                var module_binary = path.join(module_path,app.name+'.node');
+                t.ok(existsSync(module_binary));
+                t.end();
+            });
+        });
+
+        test(app.name + ' passes tests ' + app.args, function(t) {
+            run('npm','test','', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                t.ifError(err);
                 // we expect app2 to console.log on success
                 if (app.name == 'app2') {
+                    console.log(stdout);
                     if (app.args.indexOf('--debug') > -1) {
-                        assert.ok(stdout.indexOf('Loaded Debug build') > -1);
+                        t.ok(stdout.indexOf('Loaded Debug build') > -1);
                     } else {
-                        assert.ok(stdout.indexOf('Loaded Release build') > -1);
+                        t.ok(stdout.indexOf('Loaded Release build') > -1);
                     }
                 } else {
                     // we expect some npm output
-                    assert.notEqual(stdout,'');
+                    t.notEqual(stdout,'');
                 }
-                done();
+                t.end();
             });
-        }
-    });
-});
+        });
 
-
-describe('complex builds', function() {
-
-    apps.forEach(function(app) {
-
-        describe(app.name, function() {
-
-            before(function(done) {
-                // clear out entire binding directory
-                // to ensure no stale builds. This is needed
-                // because "node-pre-gyp clean" only removes
-                // the current target and not alternative builds
-                var binding_directory = path.join(__dirname,app.name,'lib/binding');
-                if (fs.existsSync(binding_directory)) {
-                    rm(binding_directory,done);
-                } else {
-                    done();
-                }
+        test(app.name + ' packages ' + app.args, function(t) {
+            run('node-pre-gyp', 'package', '', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.end();
             });
+        });
 
-            it(app.name + ' configures ' + app.args, function(done) {
-                run('node-pre-gyp', 'configure', '--loglevel=error', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                        assert.equal(stderr,'');
-                    }
-                    done();
+        test(app.name + ' package is valid ' + app.args, function(t) {
+            run('node-pre-gyp', 'testpackage', '', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.end();
+            });
+        });
+
+        if (process.env.AWS_ACCESS_KEY_ID || process.env.node_pre_gyp_accessKeyId) {
+
+            test(app.name + ' publishes ' + app.args, function(t) {
+                run('node-pre-gyp', 'unpublish publish', '', app, {}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
                 });
             });
 
-            it(app.name + ' configures with unparsed options ' + app.args, function(done) {
-                run('node-pre-gyp', 'configure', '--loglevel=info -- -Dfoo=bar', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    assert.ok(stderr.search(/(gyp info spawn args).*(-Dfoo=bar)/) > -1);
-                    done();
-                });
-            });
-
-            it(app.name + ' installs', function(done) {
-                run('node-pre-gyp', 'install', '--update-binary --fallback-to-build', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    assert.ok(stdout.search(app.name+'.node') > -1);
-                    done();
-                });
-            });
-
-            it(app.name + ' builds ' + app.args, function(done) {
-                run('node-pre-gyp', 'rebuild', '--fallback-to-build --loglevel=error', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    assert.ok(stdout.search(app.name+'.node') > -1);
-                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                        assert.equal(stderr,'');
-                    }
-                    done();
-                });
-            });
-
-            it(app.name + ' is found ' + app.args, function(done) {
-                run('node-pre-gyp', 'reveal', 'module_path --silent', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                        assert.equal(stderr,'');
-                    }
-                    var module_path = stdout.trim();
-                    assert.ok(module_path.search(app.name) > -1);
-                    assert.ok(existsSync(module_path),'is found '+ module_path);
-                    var module_binary = path.join(module_path,app.name+'.node');
-                    assert.ok(existsSync(module_binary));
-                    done();
-                });
-            });
-
-            it(app.name + ' passes tests ' + app.args, function(done) {
-                // work around https://github.com/iojs/io.js/issues/751
-                if (is_iojs && process.platform === 'win32') {
-                    run('iojs','index.js','', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        assert.equal(stderr,'');
-                        // we expect app2 to console.log on success
-                        if (app.name == 'app2') {
-                            if (app.args.indexOf('--debug') > -1) {
-                                assert.ok(stdout.indexOf('Loaded Debug build') > -1);
-                            } else {
-                                assert.ok(stdout.indexOf('Loaded Release build') > -1);
-                            }
-                        } else {
-                            assert.equal(stdout,'');
-                        }
-                        done();
-                    });
-                } else {
-                    run('npm','test','', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        // we expect app2 to console.log on success
-                        if (app.name == 'app2') {
-                            if (app.args.indexOf('--debug') > -1) {
-                                assert.ok(stdout.indexOf('Loaded Debug build') > -1);
-                            } else {
-                                assert.ok(stdout.indexOf('Loaded Release build') > -1);
-                            }
-                        } else {
-                            // we expect some npm output
-                            assert.notEqual(stdout,'');
-                        }
-                        done();
-                    });
-                }
-            });
-
-            it(app.name + ' packages ' + app.args, function(done) {
-                run('node-pre-gyp', 'package', '', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                        assert.equal(stderr,'');
-                    }
-                    done();
-                });
-            });
-
-            it(app.name + ' package is valid ' + app.args, function(done) {
-                run('node-pre-gyp', 'testpackage', '', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                        assert.equal(stderr,'');
-                    }
-                    done();
-                });
-            });
-
-            if (process.env.AWS_ACCESS_KEY_ID || process.env.node_pre_gyp_accessKeyId) {
-
-                it(app.name + ' publishes ' + app.args, function(done) {
-                    run('node-pre-gyp', 'unpublish publish', '', app, {}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        assert.notEqual(stdout,'');
-                        done();
+            test(app.name + ' info shows it ' + app.args, function(t) {
+                run('node-pre-gyp', 'reveal', 'package_name', app, {}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    var package_name = stdout.trim();
+                    run('node-pre-gyp', 'info', '', app, {}, function(err,stdout,stderr) {
+                        t.ifError(err);
+                        t.stringContains(stdout,package_name);
+                        t.end();
                     });
                 });
+            });
 
-                it(app.name + ' info shows it ' + app.args, function(done) {
-                    run('node-pre-gyp', 'reveal', 'package_name', app, {}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        assert.equal(stderr,'');
-                        assert.notEqual(stdout,'');
-                        var package_name = stdout.trim();
-                        run('node-pre-gyp', 'info', '', app, {}, function(err,stdout,stderr) {
-                            if (err) return on_error(err,stdout,stderr);
-                            if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                                assert.equal(stderr,'');
-                            }
-                            assert.ok(stdout.indexOf(package_name) > -1);
-                            done();
-                        });
-                    });
-                });
-
-                it(app.name + ' can be uninstalled ' + app.args, function(done) {
-                    run('node-pre-gyp', 'clean', '', app, {}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        assert.notEqual(stdout,'');
-                        done();
-                    });
-                });
-
-                it(app.name + ' can be installed via remote ' + app.args, function(done) {
-                    run('npm', 'install', '--fallback-to-build=false', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        assert.notEqual(stdout,'');
-                        done();
-                    });
-                });
-
-                it(app.name + ' can be reinstalled via remote ' + app.args, function(done) {
-                    run('npm', 'install', '--update-binary --fallback-to-build=false', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        assert.notEqual(stdout,'');
-                        done();
-                    });
-                });
-
-                it(app.name + ' via remote passes tests ' + app.args, function(done) {
-                    run('npm', 'install', '', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        assert.notEqual(stdout,'');
-                        done();
-                    });
-                });
-
-            } else {
-                it.skip(app.name + ' publishes ' + app.args, function() {});
-            }
-
-            it(app.name + ' builds with unparsed options ' + app.args, function(done) {
+            test(app.name + ' can be uninstalled ' + app.args, function(t) {
                 run('node-pre-gyp', 'clean', '', app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    run('node-pre-gyp', 'build', '--loglevel=info -- ' + propertyPrefix + 'FOO=bar', app, {}, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        assert.ok(stdout.search(app.name+'.node') > -1);
-                        assert.ok(stderr.search(/(gyp info spawn args).*(FOO=bar)/) > -1);
-                        done();
-                    });
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
                 });
             });
 
-            // make sure node-gyp options are passed by passing invalid values
-            // and ensuring the expected errors are returned from node-gyp
-            //Python executable "foo"
-            it(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.args, function(done) {
-                run('node-pre-gyp', 'configure', '--nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
-                    assert.ok(err);
-                    assert.ok(stdout.search(app.name+'.node') > -1);
-                    assert.ok(stderr.indexOf('common.gypi not found' > -1));
-                    done();
+            test(app.name + ' can be installed via remote ' + app.args, function(t) {
+                run('npm', 'install', '--fallback-to-build=false', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
                 });
             });
 
-            it(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(done) {
-                run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
-                    assert.ok(err);
-                    assert.ok(stdout.search(app.name+'.node') > -1);
-                    assert.ok(stderr.indexOf('common.gypi not found' > -1));
-                    done();
+            test(app.name + ' can be reinstalled via remote ' + app.args, function(t) {
+                run('npm', 'install', '--update-binary --fallback-to-build=false', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
                 });
             });
 
-            // TODO - for some reason these do not error on windows
-            if (process.platform !== 'win32') {
-                it(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(done) {
-                    run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
-                        assert.ok(err);
-                        assert.ok(stdout.search(app.name+'.node') > -1);
-                        assert.ok(stderr.indexOf("Can't find Python executable" > -1));
-                        done();
-                    });
-                });
-
-                it(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(done) {
-                    run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
-                        assert.ok(err);
-                        assert.ok(stdout.search(app.name+'.node') > -1);
-                        assert.ok(stderr.indexOf("Can't find Python executable" > -1));
-                        done();
-                    });
-                });
-            }
-            // note: --ensure=false tells node-gyp to attempt to re-download the node headers
-            // even if they already exist on disk at ~/.node-gyp/{version}
-            it(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(done) {
-                run('node-pre-gyp', 'configure', '--ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
-                    assert.ok(err);
-                    assert.ok(stderr.indexOf('Invalid protocol: null' > -1));
-                    done();
+            test(app.name + ' via remote passes tests ' + app.args, function(t) {
+                run('npm', 'install', '', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
                 });
             });
 
-            it(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(done) {
-                run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
-                    assert.ok(err);
-                    assert.ok(stderr.indexOf('Invalid protocol: null' > -1));
-                    done();
-                });
-            });
+        } else {
+            test.skip(app.name + ' publishes ' + app.args, function() {});
+        }
 
-            if (target_abi) {
-                var new_env = JSON.parse(JSON.stringify(process.env));
-                new_env.NODE_PRE_GYP_ABI_CROSSWALK = testing_crosswalk;
-                var opts = { env : new_env };
-                it(app.name + ' builds with custom --target='+previous_version+' that is greater than known version in ABI crosswalk ' + app.args, function(done) {
-                    run('node-pre-gyp', 'rebuild', '--loglevel=error --fallback-to-build --target='+previous_version, app, opts, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        assert.ok(stdout.search(app.name+'.node') > -1);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        done();
-                    });
-                });
-
-                it(app.name + ' cleans up after installing custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function(done) {
-                    run('node-pre-gyp', 'clean', '--target='+previous_version, app, opts, function(err,stdout,stderr) {
-                        if (err) return on_error(err,stdout,stderr);
-                        if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                            assert.equal(stderr,'');
-                        }
-                        assert.notEqual(stdout,'');
-                        done();
-                    });
-                });
-
-            } else {
-                it.skip(app.name + ' builds with custom --target that is greater than known in ABI crosswalk ' + app.args, function() {});
-                it.skip(app.name + ' builds with custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function() {});
-            }
-
-            // note: the above test will result in a non-runnable binary, so the below test must succeed otherwise all following tests will fail
-
-            it(app.name + ' builds with custom --target ' + app.args, function(done) {
-                run('node-pre-gyp', 'rebuild', '--loglevel=error --fallback-to-build --target='+process.versions.node, app, {}, function(err,stdout,stderr) {
-                    if (err) return on_error(err,stdout,stderr);
-                    assert.ok(stdout.search(app.name+'.node') > -1);
-                    if (stderr.indexOf("child_process: customFds option is deprecated, use stdio instead") == -1) {
-                        assert.equal(stderr,'');
-                    }
-                    done();
+        test(app.name + ' builds with unparsed options ' + app.args, function(t) {
+            run('node-pre-gyp', 'clean', '', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                run('node-pre-gyp', 'build', '--loglevel=info -- ' + propertyPrefix + 'FOO=bar', app, {}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.ok(stderr.search(/(gyp info spawn args).*(FOO=bar)/) > -1);
+                    t.end();
                 });
             });
         });
-    });
+
+        // make sure node-gyp options are passed by passing invalid values
+        // and ensuring the expected errors are returned from node-gyp
+        //Python executable "foo"
+        test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+            run('node-pre-gyp', 'configure', '--nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
+                t.ok(err);
+                t.ok(stderr.indexOf('common.gypi not found' > -1));
+                t.end();
+            });
+        });
+
+        test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
+            run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
+                t.ok(err);
+                t.ok(stderr.indexOf('common.gypi not found' > -1));
+                t.end();
+            });
+        });
+
+        // TODO - for some reason these do not error on windows
+        if (process.platform !== 'win32') {
+            test(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+                run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
+                    t.ok(err);
+                    t.ok(stderr.indexOf("Can't find Python executable" > -1));
+                    t.end();
+                });
+            });
+
+            test(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(t) {
+                run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
+                    t.ok(err);
+                    t.ok(stderr.indexOf("Can't find Python executable" > -1));
+                    t.end();
+                });
+            });
+        }
+        // note: --ensure=false tells node-gyp to attempt to re-download the node headers
+        // even if they already exist on disk at ~/.node-gyp/{version}
+        test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+            run('node-pre-gyp', 'configure', '--ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
+                t.ok(err);
+                t.ok(stderr.indexOf('Invalid protocol: null' > -1));
+                t.end();
+            });
+        });
+
+        test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
+            run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
+                t.ok(err);
+                t.ok(stderr.indexOf('Invalid protocol: null' > -1));
+                t.end();
+            });
+        });
+
+        if (target_abi) {
+            var new_env = JSON.parse(JSON.stringify(process.env));
+            new_env.NODE_PRE_GYP_ABI_CROSSWALK = testing_crosswalk;
+            var opts = { env : new_env };
+            test(app.name + ' builds with custom --target='+previous_version+' that is greater than known version in ABI crosswalk ' + app.args, function(t) {
+                run('node-pre-gyp', 'rebuild', '--loglevel=error --fallback-to-build --target='+previous_version, app, opts, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.end();
+                });
+            });
+
+            test(app.name + ' cleans up after installing custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function(t) {
+                run('node-pre-gyp', 'clean', '--target='+previous_version, app, opts, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
+                });
+            });
+
+        } else {
+            test.skip(app.name + ' builds with custom --target that is greater than known in ABI crosswalk ' + app.args, function() {});
+            test.skip(app.name + ' builds with custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function() {});
+        }
+
+        // note: the above test will result in a non-runnable binary, so the below test must succeed otherwise all following tests will fail
+
+        test(app.name + ' builds with custom --target ' + app.args, function(t) {
+            run('node-pre-gyp', 'rebuild', '--loglevel=error --fallback-to-build --target='+process.versions.node, app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.end();
+            });
+        });
 });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -32,7 +32,12 @@ function run(prog,command,args,app,opts,cb) {
     }
     final_cmd += ' ' + app.args;
     final_cmd += ' ' + args;
-    cp.exec('V=1 '+final_cmd,opts,function(err,stdout,stderr) {
+    // on unix display compile args
+    if (process.platform !== 'win32') {
+        final_cmd = 'V=1 ' + final_cmd;
+    }
+
+    cp.exec(final_cmd,opts,function(err,stdout,stderr) {
         if (err) {
             var error = new Error("Command failed '" + final_cmd + "'");
             error.stack = stderr;
@@ -145,10 +150,12 @@ apps.forEach(function(app) {
         test(app.name + ' builds ' + app.args, function(t) {
             run('node-pre-gyp', 'rebuild', '--fallback-to-build --loglevel=error', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
-                if (app.args.indexOf('--debug') > -1) {
-                    t.stringContains(stdout,'Debug/'+app.name+'.node');
-                } else {
-                    t.stringContains(stdout,'Release/'+app.name+'.node');
+                if (process.platform !== 'win32') {
+                    if (app.args.indexOf('--debug') > -1) {
+                        t.stringContains(stdout,'Debug/'+app.name+'.node');
+                    } else {
+                        t.stringContains(stdout,'Release/'+app.name+'.node');
+                    }
                 }
                 t.end();
             });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -180,9 +180,9 @@ apps.forEach(function(app) {
                 if (app.name == 'app2') {
                     console.log(stdout);
                     if (app.args.indexOf('--debug') > -1) {
-                        t.ok(stdout.indexOf('Loaded Debug build') > -1);
+                        t.stringContains(stdout,'Loaded Debug build');
                     } else {
-                        t.ok(stdout.indexOf('Loaded Release build') > -1);
+                        t.stringContains(stdout,'Loaded Release build');
                     }
                 } else {
                     // we expect some npm output
@@ -281,7 +281,7 @@ apps.forEach(function(app) {
         test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.args, function(t) {
             run('node-pre-gyp', 'configure', '--nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
                 t.ok(err);
-                t.ok(stderr.indexOf('common.gypi not found' > -1));
+                t.stringContains(stderr,"common.gypi not found");
                 t.end();
             });
         });
@@ -289,7 +289,7 @@ apps.forEach(function(app) {
         test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
             run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
                 t.ok(err);
-                t.ok(stderr.indexOf('common.gypi not found' > -1));
+                t.stringContains(stderr,"common.gypi not found");
                 t.end();
             });
         });
@@ -299,7 +299,7 @@ apps.forEach(function(app) {
             test(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(t) {
                 run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
                     t.ok(err);
-                    t.ok(stderr.indexOf("Can't find Python executable" > -1));
+                    t.stringContains(stderr,"Can't find Python executable");
                     t.end();
                 });
             });
@@ -307,7 +307,7 @@ apps.forEach(function(app) {
             test(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(t) {
                 run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
                     t.ok(err);
-                    t.ok(stderr.indexOf("Can't find Python executable" > -1));
+                    t.stringContains(stderr,"Can't find Python executable");
                     t.end();
                 });
             });
@@ -317,7 +317,7 @@ apps.forEach(function(app) {
         test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(t) {
             run('node-pre-gyp', 'configure', '--ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
                 t.ok(err);
-                t.ok(stderr.indexOf('Invalid protocol: null' > -1));
+                t.stringContains(stderr,'Invalid');
                 t.end();
             });
         });
@@ -325,7 +325,7 @@ apps.forEach(function(app) {
         test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
             run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
                 t.ok(err);
-                t.ok(stderr.indexOf('Invalid protocol: null' > -1));
+                t.stringContains(stderr,'Invalid');
                 t.end();
             });
         });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -317,7 +317,6 @@ apps.forEach(function(app) {
         test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(t) {
             run('node-pre-gyp', 'configure', '--ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
                 t.ok(err);
-                t.stringContains(stderr,'Invalid');
                 t.end();
             });
         });
@@ -325,7 +324,6 @@ apps.forEach(function(app) {
         test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
             run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
                 t.ok(err);
-                t.stringContains(stderr,'Invalid');
                 t.end();
             });
         });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,52 +1,14 @@
 "use strict";
 
 var test = require('tape');
-var cp = require('child_process');
-var path = require('path');
+var run = require('./run.util.js');
 var existsSync = require('fs').existsSync || require('path').existsSync;
-var abi_crosswalk = require('../lib/util/abi_crosswalk.json');
-var os = require('os');
 var fs = require('fs');
 var rm = require('rimraf');
+var path = require('path');
+var getPrevious = require('./target_version.util.js');
 
-var cmd_path = path.join(__dirname,'../bin/');
-var sep = ':';
-var propertyPrefix = '';
-if (process.platform === 'win32') {
-    sep = ';';
-    propertyPrefix = '/p:';
-}
-process.env.PATH = cmd_path + sep + process.env.PATH;
-process.env.NODE_PATH = path.join(__dirname,'../lib/');
-
-function run(prog,command,args,app,opts,cb) {
-    var final_cmd = prog + ' ' + command;
-    if (!opts.cwd) {
-        final_cmd += ' -C ' + path.join(__dirname,app.name);
-    }
-    // clang=1 is harmless to add, but avoids breakage on `-fno-tree-sink`
-    // flag that nodejs gyp scripts add and clang does not know about
-    final_cmd += ' --clang=1';
-    if (process.platform === 'win32') {
-        final_cmd += ' --msvs_version=2015 ';
-    }
-    final_cmd += ' ' + app.args;
-    final_cmd += ' ' + args;
-    // on unix display compile args
-    if (process.platform !== 'win32') {
-        final_cmd = 'V=1 ' + final_cmd;
-    }
-
-    cp.exec(final_cmd,opts,function(err,stdout,stderr) {
-        if (err) {
-            var error = new Error("Command failed '" + final_cmd + "'");
-            error.stack = stderr;
-            return cb(error,stdout,stderr);
-        }
-        return cb(err,stdout,stderr);
-    });
-}
-
+// The list of different sample apps that we use to test
 var apps = [
     {
         'name': 'app1',
@@ -70,35 +32,6 @@ var apps = [
     }
 ];
 
-function getPreviousVersion(current_version) {
-    var current_parts = current_version.split('.').map(function(i) { return +i; });
-    var major = current_parts[0];
-    var minor = current_parts[1];
-    var patch = current_parts[2];
-    while (patch > 0) {
-        --patch;
-        var new_target = '' + major + '.' + minor + '.' + patch;
-        if (new_target == current_version) {
-            break;
-        }
-        if (abi_crosswalk[new_target]) {
-            return new_target;
-        }
-    }
-    // failed to find suitable future version that we expect is ABI compatible
-    return undefined;
-}
-
-var current_version = process.version.replace('v','');
-var previous_version = getPreviousVersion(current_version);
-var target_abi;
-var testing_crosswalk;
-if (previous_version !== undefined && previous_version !== current_version) {
-    target_abi = {};
-    target_abi[previous_version] = abi_crosswalk[previous_version];
-    testing_crosswalk = path.join(os.tmpdir(),'fake_abi_crosswalk.json');
-    fs.writeFileSync(testing_crosswalk,JSON.stringify(target_abi));
-}
 
 // https://stackoverflow.com/questions/38599457/how-to-write-a-custom-assertion-for-testing-node-or-javascript-with-tape-or-che
 test.Test.prototype.stringContains = function(actual, contents, message) {
@@ -109,6 +42,65 @@ test.Test.prototype.stringContains = function(actual, contents, message) {
     expected: contents
   });
 };
+
+// Because the below tests only ensure that flags can be correctly passed to node-gyp is it not
+// likely they will behave differently for different apps. So we save time by avoiding running these for each app.
+var app = apps[0];
+
+// make sure node-gyp options are passed by passing invalid values
+// and ensuring the expected errors are returned from node-gyp
+test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+    run('node-pre-gyp', 'configure', '--nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
+        t.ok(err,'Expected command to fail');
+        t.stringContains(stderr,"common.gypi not found");
+        t.end();
+    });
+});
+
+test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
+    run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
+        t.ok(err, 'Expected command to fail');
+        t.stringContains(stderr,"common.gypi not found");
+        t.end();
+    });
+});
+
+// TODO - for some reason these do not error on windows
+if (process.platform !== 'win32') {
+    test(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+        run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
+            t.ok(err, 'Expected command to fail');
+            t.stringContains(stderr,"Can't find Python executable");
+            t.end();
+        });
+    });
+
+    test(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(t) {
+        run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
+            t.ok(err, 'Expected command to fail');
+            t.stringContains(stderr,"Can't find Python executable");
+            t.end();
+        });
+    });
+}
+// note: --ensure=false tells node-gyp to attempt to re-download the node headers
+// even if they already exist on disk at ~/.node-gyp/{version}
+test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(t) {
+    run('node-pre-gyp', 'configure', '--ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
+        t.ok(err, 'Expected command to fail');
+        t.end();
+    });
+});
+
+test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
+    run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
+        t.ok(err, 'Expected command to fail');
+        t.end();
+    });
+});
+
+
+// Tests run for all apps
 
 apps.forEach(function(app) {
 
@@ -139,11 +131,24 @@ apps.forEach(function(app) {
             });
         });
 
-        test(app.name + ' installs', function(t) {
-            run('node-pre-gyp', 'install', '--update-binary --fallback-to-build', app, {}, function(err,stdout,stderr) {
+        test(app.name + ' builds with unparsed options ' + app.args, function(t) {
+            // clean and build as separate steps here because configure only works with -Dfoo=bar
+            // and build only works with FOO=bar
+            run('node-pre-gyp', 'clean', '', app, {}, function(err) {
                 t.ifError(err);
-                t.stringContains(stdout,'Success: ');
-                t.end();
+                var propertyPrefix = (process.platform === 'win32') ? '/p:' : '';
+                run('node-pre-gyp', 'build', '--loglevel=info -- ' + propertyPrefix + 'FOO=bar', app, {}, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.ok(stderr.search(/(gyp info spawn args).*(FOO=bar)/) > -1);
+                    if (process.platform !== 'win32') {
+                        if (app.args.indexOf('--debug') > -1) {
+                            t.stringContains(stdout,'Debug/'+app.name+'.node');
+                        } else {
+                            t.stringContains(stdout,'Release/'+app.name+'.node');
+                        }
+                    }
+                    t.end();
+                });
             });
         });
 
@@ -165,8 +170,8 @@ apps.forEach(function(app) {
             run('node-pre-gyp', 'reveal', 'module_path --silent', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
                 var module_path = stdout.trim();
-                t.ok(module_path.search(app.name) > -1);
-                t.ok(existsSync(module_path),'is found '+ module_path);
+                t.stringContains(module_path,app.name);
+                t.ok(existsSync(module_path),'is valid path to existing binary: '+ module_path);
                 var module_binary = path.join(module_path,app.name+'.node');
                 t.ok(existsSync(module_binary));
                 t.end();
@@ -174,11 +179,10 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' passes tests ' + app.args, function(t) {
-            run('npm','test','', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+            run('npm','test','', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                 t.ifError(err);
                 // we expect app2 to console.log on success
                 if (app.name == 'app2') {
-                    console.log(stdout);
                     if (app.args.indexOf('--debug') > -1) {
                         t.stringContains(stdout,'Loaded Debug build');
                     } else {
@@ -237,7 +241,7 @@ apps.forEach(function(app) {
             });
 
             test(app.name + ' can be installed via remote ' + app.args, function(t) {
-                run('npm', 'install', '--fallback-to-build=false', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                run('npm', 'install', '--fallback-to-build=false', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                     t.ifError(err);
                     t.notEqual(stdout,'');
                     t.end();
@@ -245,7 +249,7 @@ apps.forEach(function(app) {
             });
 
             test(app.name + ' can be reinstalled via remote ' + app.args, function(t) {
-                run('npm', 'install', '--update-binary --fallback-to-build=false', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                run('npm', 'install', '--update-binary --fallback-to-build=false', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                     t.ifError(err);
                     t.notEqual(stdout,'');
                     t.end();
@@ -253,7 +257,7 @@ apps.forEach(function(app) {
             });
 
             test(app.name + ' via remote passes tests ' + app.args, function(t) {
-                run('npm', 'install', '', app, {env : process.env, cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
+                run('npm', 'install', '', app, {cwd: path.join(__dirname,app.name)}, function(err,stdout,stderr) {
                     t.ifError(err);
                     t.notEqual(stdout,'');
                     t.end();
@@ -262,94 +266,6 @@ apps.forEach(function(app) {
 
         } else {
             test.skip(app.name + ' publishes ' + app.args, function() {});
-        }
-
-        test(app.name + ' builds with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'clean', '', app, {}, function(err,stdout,stderr) {
-                t.ifError(err);
-                run('node-pre-gyp', 'build', '--loglevel=info -- ' + propertyPrefix + 'FOO=bar', app, {}, function(err,stdout,stderr) {
-                    t.ifError(err);
-                    t.ok(stderr.search(/(gyp info spawn args).*(FOO=bar)/) > -1);
-                    t.end();
-                });
-            });
-        });
-
-        // make sure node-gyp options are passed by passing invalid values
-        // and ensuring the expected errors are returned from node-gyp
-        //Python executable "foo"
-        test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.args, function(t) {
-            run('node-pre-gyp', 'configure', '--nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
-                t.ok(err);
-                t.stringContains(stderr,"common.gypi not found");
-                t.end();
-            });
-        });
-
-        test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
-            run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
-                t.ok(err);
-                t.stringContains(stderr,"common.gypi not found");
-                t.end();
-            });
-        });
-
-        // TODO - for some reason these do not error on windows
-        if (process.platform !== 'win32') {
-            test(app.name + ' passes --python down to node-gyp via node-pre-gyp ' + app.args, function(t) {
-                run('node-pre-gyp', 'configure', '--python=invalid-value', app, {}, function(err,stdout,stderr) {
-                    t.ok(err);
-                    t.stringContains(stderr,"Can't find Python executable");
-                    t.end();
-                });
-            });
-
-            test(app.name + ' passes --python down to node-gyp via npm ' + app.args, function(t) {
-                run('node-pre-gyp', 'configure', '--build-from-source --python=invalid-value', app, {}, function(err,stdout,stderr) {
-                    t.ok(err);
-                    t.stringContains(stderr,"Can't find Python executable");
-                    t.end();
-                });
-            });
-        }
-        // note: --ensure=false tells node-gyp to attempt to re-download the node headers
-        // even if they already exist on disk at ~/.node-gyp/{version}
-        test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.args, function(t) {
-            run('node-pre-gyp', 'configure', '--ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
-                t.ok(err);
-                t.end();
-            });
-        });
-
-        test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
-            run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
-                t.ok(err);
-                t.end();
-            });
-        });
-
-        if (target_abi) {
-            var new_env = JSON.parse(JSON.stringify(process.env));
-            new_env.NODE_PRE_GYP_ABI_CROSSWALK = testing_crosswalk;
-            var opts = { env : new_env };
-            test(app.name + ' builds with custom --target='+previous_version+' that is greater than known version in ABI crosswalk ' + app.args, function(t) {
-                run('node-pre-gyp', 'rebuild', '--loglevel=error --fallback-to-build --target='+previous_version, app, opts, function(err,stdout,stderr) {
-                    t.ifError(err);
-                    t.end();
-                });
-            });
-
-            test(app.name + ' cleans up after installing custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function(t) {
-                run('node-pre-gyp', 'clean', '--target='+previous_version, app, opts, function(err,stdout,stderr) {
-                    t.ifError(err);
-                    t.notEqual(stdout,'');
-                    t.end();
-                });
-            });
-
-        } else {
-            test.skip(app.name + ' builds with custom --target that is greater than known in ABI crosswalk ' + app.args, function() {});
-            test.skip(app.name + ' builds with custom --target='+previous_version+' that is greater than known in ABI crosswalk ' + app.args, function() {});
         }
 
         // note: the above test will result in a non-runnable binary, so the below test must succeed otherwise all following tests will fail

--- a/test/run.util.js
+++ b/test/run.util.js
@@ -1,0 +1,84 @@
+var cp = require('child_process');
+var path = require('path');
+
+
+/*
+
+Convenience function to call out to local node-pre-gyp or npm
+
+*/
+
+var cmd_path = path.join(__dirname,'../bin/');
+var sep = ':';
+if (process.platform === 'win32') {
+    sep = ';';
+}
+
+function run(prog,command,args,app,opts,cb) {
+
+    // validate args
+    if (!prog) throw new Error("prog arg undefined");
+    if (!command) throw new Error("command arg undefined");
+    if (!app) throw new Error("app arg undefined");
+    if (!app.name) throw new Error("app.name undefined");
+
+
+    // start forming up the command we will execute.
+    // here we add the program and the command
+    var final_cmd = prog + ' ' + command;
+
+    // if we are calling out to `node-pre-gyp` let's ensure we directly
+    // call the local version at a relative path (to avoid the change) we might
+    // use some external version on PATH
+    if (final_cmd.indexOf('node-pre-gyp') > -1) {
+        final_cmd = cmd_path + final_cmd;
+    }
+
+    // if npm we need to put our local node_gyp on path
+    if (final_cmd.indexOf('npm') > -1) {
+        opts.env = process.env;
+        // needed for npm to find node-pre-gyp locally
+        opts.env.PATH = cmd_path + sep + process.env.PATH;
+        // needed for apps that require node-pre-gyp to find local module
+        // since they don't install a copy in their node_modules
+        opts.env.NODE_PATH = NODE_PATH = path.join(__dirname,'../lib/');
+    }
+
+    // unless explicitly provided, lets execute the command inside the app specific directory
+    if (!opts.cwd) {
+        final_cmd += ' -C ' + path.join(__dirname,app.name);
+    }
+    // avoid breakage when compiling with clang++ and node v0.10.x
+    // This is harmless to add for other versions and platforms
+    final_cmd += ' --clang=1';
+    
+    // Test building with msvs 2015 since that is more edge case than 2013
+    if (process.platform === 'win32') {
+        final_cmd += ' --msvs_version=2015 ';
+    }
+
+    // finish appending all arguments
+    final_cmd += ' ' + app.args;
+    final_cmd += ' ' + args;
+
+
+    // On unix we want to display compile args (rather than have them hidden)
+    // for easier debugging of unexpected compile failures.
+    // We do this by pre-pending the magic variable that make responds to.
+    if (process.platform !== 'win32') {
+        final_cmd = 'V=1 ' + final_cmd;
+    }
+
+    // Finally, execute the command
+
+    cp.exec(final_cmd,opts,function(err,stdout,stderr) {
+        if (err) {
+            var error = new Error("Command failed '" + final_cmd + "'");
+            error.stack = stderr;
+            return cb(error,stdout,stderr);
+        }
+        return cb(err,stdout,stderr);
+    });
+}
+
+module.exports = run;

--- a/test/s3_setup.test.js
+++ b/test/s3_setup.test.js
@@ -1,22 +1,22 @@
 "use strict";
 
 var s3_setup = require('../lib/util/s3_setup.js');
-var assert = require('assert');
+var test = require('tape');
 
-describe('s3_setup', function() {
-    it('should propertly detect s3 bucket and prefix', function() {
-        var url = "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com";
-        var result = {};
-        s3_setup.detect(url, result);
-        assert.equal(result.prefix,'');
-        assert.equal(result.bucket,'node-pre-gyp-tests');
-    });
+test('should propertly detect s3 bucket and prefix', function(t) {
+    var url = "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com";
+    var result = {};
+    s3_setup.detect(url, result);
+    t.equal(result.prefix,'');
+    t.equal(result.bucket,'node-pre-gyp-tests');
+    t.end();
+});
 
-    it('should propertly detect s3 bucket and prefix with dots', function() {
-        var url = "https://bucket.with.dots.s3.amazonaws.com/prefix";
-        var result = {};
-        s3_setup.detect(url, result);
-        assert.equal(result.prefix,'prefix');
-        assert.equal(result.bucket,'bucket.with.dots');
-    });
+test('should propertly detect s3 bucket and prefix with dots', function(t) {
+    var url = "https://bucket.with.dots.s3.amazonaws.com/prefix";
+    var result = {};
+    s3_setup.detect(url, result);
+    t.equal(result.prefix,'prefix');
+    t.equal(result.bucket,'bucket.with.dots');
+    t.end();
 });

--- a/test/target_version.test.js
+++ b/test/target_version.test.js
@@ -1,0 +1,111 @@
+"use strict";
+
+var getPrevious = require('./target_version.util.js');
+var run = require('./run.util.js');
+var abi_crosswalk = require('../lib/util/abi_crosswalk.json');
+var os = require('os');
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
+
+test('should properly calculate previous version', function(t) {
+    t.equal(getPrevious('1.0.0',abi_crosswalk),undefined);
+    t.equal(getPrevious('1.0.1',abi_crosswalk),'1.0.0');
+    t.equal(getPrevious('1.0.2',abi_crosswalk),'1.0.1');
+    t.end();
+});
+
+/*
+
+Context:
+
+node-pre-gyp can "cross-install" which means that you can install binaries for a given node version that is
+different than the node version you are running. This is possible by passing the `--target` flag with a value
+for a given node version you want to target like `--target=4.3.4`.
+
+Internally node-pre-gyp will take this version (4.3.4), figure out the ABI version for it (aka `process.versions.modules`)
+and then install the right binary.
+
+*/
+
+// Get all major values for released node versions we know about
+var versions = [];
+Object.keys(abi_crosswalk).forEach(function(v) {
+    var major = +v.split('.')[0];
+    //console.log(major)
+    if (!(versions.indexOf(major) > -1)) {
+        versions.push(major);
+    }
+});
+
+test('every major version should have a unique ABI that is consistent across all major versions', function(t) {
+    var abis = {};
+    Object.keys(abi_crosswalk).forEach(function(v) {
+       var major = +v.split('.')[0];
+       if (major >= 2) {
+            var o = abi_crosswalk[v];
+            if (!abis[major]) {
+                abis[major] = o.node_abi;
+            } else {
+                t.equal(abis[major],o.node_abi,v + ' should have abi: ' + o.node_abi);
+            }
+       }
+    });
+    t.end();
+});
+
+var found = false;
+var current_version = process.versions.node;
+var major = +(current_version.split('.')[0]);
+
+test('ensure crosswalk has major version of current node', function(t) {
+    found = versions.indexOf(major) > -1;
+    t.ok(found);
+    t.end();
+});
+
+/*
+If we know:
+
+ - the current version is in the crosswalk
+ - it has a previous patch version (it is at least x.x.1)
+ - and that x.x.1 has been released
+
+Then we test the --target flag by:
+
+  - pretending current version is the previous version
+  - the current version does not exist in the abi_crosswalk (by mocking it)
+*/
+
+var previous_patch_version = getPrevious(current_version,abi_crosswalk);
+
+if (previous_patch_version && previous_patch_version !== current_version) {
+
+    var app = {'name': 'app1', 'args': '' };
+
+    test(app.name + ' builds with custom --target='+previous_patch_version+' that is greater than known version in ABI crosswalk ' + app.args, function(t) {
+        if (found) {
+            // construct a mock abi_crosswalk that contains only the previous node version
+            // and not the current node version
+            var target_abi = {};
+            target_abi[previous_patch_version] = abi_crosswalk[previous_patch_version];
+            // write this crosswalk to disk
+            var testing_crosswalk = path.join(os.tmpdir(),'fake_abi_crosswalk.json');
+            fs.writeFileSync(testing_crosswalk,JSON.stringify(target_abi));
+            // pass mock crosswalk to env so that the node-pre-gyp we shell out to
+            // uses the mock crosswalk
+            var new_env = JSON.parse(JSON.stringify(process.env));
+            new_env.NODE_PRE_GYP_ABI_CROSSWALK = testing_crosswalk;
+            var opts = { env : new_env };
+            run('node-pre-gyp', 'rebuild', '--loglevel=error --fallback-to-build --target='+previous_patch_version, app, opts, function(err,stdout,stderr) {
+                t.ifError(err);
+                run('node-pre-gyp', 'clean', '--target='+current_version, app, opts, function(err,stdout,stderr) {
+                    t.ifError(err);
+                    t.notEqual(stdout,'');
+                    t.end();
+                });
+            });
+        }
+    });
+}
+

--- a/test/target_version.util.js
+++ b/test/target_version.util.js
@@ -1,0 +1,30 @@
+
+/*
+
+Takes the current version (major.minor.patch) and returns the previous patch version.
+
+For a version like `v1.0.0` this would return `undefined`
+
+For a version like `v1.0.1` this would return `v1.0.0`
+
+*/
+function getPreviousVersion(current_version, abi_crosswalk) {
+    var current_parts = current_version.split('.').map(function(i) { return +i; });
+    var major = current_parts[0];
+    var minor = current_parts[1];
+    var patch = current_parts[2];
+    while (patch > 0) {
+        --patch;
+        var new_target = '' + major + '.' + minor + '.' + patch;
+        if (new_target == current_version) {
+            break;
+        }
+        if (abi_crosswalk[new_target]) {
+            return new_target;
+        }
+    }
+    // failed to find suitable future version that we expect is ABI compatible
+    return undefined;
+}
+
+module.exports = getPreviousVersion;

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -2,105 +2,111 @@
 
 var path = require('path');
 var versioning = require('../lib/util/versioning.js');
-var assert = require('assert');
+var test = require('tape');
 
-describe('versioning', function() {
-    it('should normalize double slash', function() {
-        var mock_package_json = {
-            "name"   : "test",
-            "main"   : "test.js",
-            "version": "0.1.0",
-            "binary" : {
-                "module_name" : "test",
-                "module_path" : "./lib/binding/{configuration}/{toolset}/{name}",
-                "remote_path" : "./{name}/v{version}/{configuration}/{version}/{toolset}/",
-                "package_name": "{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz",
-                "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
-            }
-        };
-        var opts = versioning.evaluate(mock_package_json, {});
-        assert.equal(opts.remote_path,"./test/v0.1.0/Release/0.1.0/");
-        // Node v0.11.x on windows lowercases C:// when path.join is called
-        // https://github.com/joyent/node/issues/7031
-        assert.equal(path.normalize(opts.module_path),path.join(process.cwd(),"lib/binding/Release/test"));
-        var opts_toolset = versioning.evaluate(mock_package_json, {toolset:"custom-toolset"});
-        assert.equal(opts_toolset.remote_path,"./test/v0.1.0/Release/0.1.0/custom-toolset/");
-    });
-
-    it('should detect abi for node process', function() {
-        var mock_process_versions = {
-            node: '0.10.33',
-            v8: '3.14.5.9',
-            modules: '11',
-        };
-        var abi = versioning.get_node_abi('node',mock_process_versions);
-        assert.equal(abi,'node-v11');
-        assert.equal(versioning.get_runtime_abi('node',undefined),versioning.get_node_abi('node',process.versions));
-    });
-
-    it('should detect abi for odd node target', function() {
-        var mock_process_versions = {
-            node: '0.11.1000000',
-            modules: 'bogus',
-        };
-        var abi = versioning.get_node_abi('node',mock_process_versions);
-        assert.equal(abi,'node-v0.11.1000000');
-    });
-
-    it('should detect abi for custom node target', function() {
-        var mock_process_versions = {
-            "node": '0.10.0',
-            "modules": '11',
-        };
-        assert.equal(versioning.get_runtime_abi('node','0.10.0'),versioning.get_node_abi('node',mock_process_versions));
-        var mock_process_versions2 = {
-            "node": '0.8.0',
-            "v8": "3.11"
-        };
-        assert.equal(versioning.get_runtime_abi('node','0.8.0'),versioning.get_node_abi('node',mock_process_versions2));
-    });
-
-    it('should detect runtime for node-webkit and electron', function() {
-        var mock_process_versions = {
-            "electron": '0.37.3',
-        };
-        assert.equal(versioning.get_process_runtime(mock_process_versions),'electron');
-        var mock_process_versions2 = {
-            "node": '0.8.0',
-        };
-        assert.equal(versioning.get_process_runtime(mock_process_versions2),'node');
-        var mock_process_versions3 = {
-            "node-webkit": '0.37.3',
-        };
-        assert.equal(versioning.get_process_runtime(mock_process_versions3),'node-webkit');
-    });
-
-    it('should detect abi for electron runtime', function() {
-        assert.equal(versioning.get_runtime_abi('electron','0.37.3'),versioning.get_electron_abi('electron','0.37.3'));
-    });
-
-    it('should detect abi for node-webkit runtime', function() {
-        assert.equal(versioning.get_runtime_abi('node-webkit','0.10.5'),versioning.get_node_webkit_abi('node-webkit','0.10.5'));
-    });
-
-    it('should detect custom binary host from env', function() {
-        var mock_package_json = {
-            "name"   : "test",
-            "main"   : "test.js",
-            "version": "0.1.0",
-            "binary" : {
-                "module_name" : "test",
-                "module_path" : "./lib/binding/{configuration}/{toolset}/{name}",
-                "remote_path" : "./{name}/v{version}/{configuration}/{version}/{toolset}/",
-                "package_name": "{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz",
-                "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
-            }
-        };
-        // mock npm_config_test_binary_host_mirror env
-        process.env.npm_config_test_binary_host_mirror = 'https://npm.taobao.org/mirrors/node-inspector/';
-        var opts = versioning.evaluate(mock_package_json, {});
-        assert.equal(opts.host,'https://npm.taobao.org/mirrors/node-inspector/');
-        delete process.env.npm_config_test_binary_host_mirror;
-    });
-
+test('should normalize double slash', function(t) {
+    var mock_package_json = {
+        "name"   : "test",
+        "main"   : "test.js",
+        "version": "0.1.0",
+        "binary" : {
+            "module_name" : "test",
+            "module_path" : "./lib/binding/{configuration}/{toolset}/{name}",
+            "remote_path" : "./{name}/v{version}/{configuration}/{version}/{toolset}/",
+            "package_name": "{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz",
+            "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
+        }
+    };
+    var opts = versioning.evaluate(mock_package_json, {});
+    t.equal(opts.remote_path,"./test/v0.1.0/Release/0.1.0/");
+    // Node v0.11.x on windows lowercases C:// when path.join is called
+    // https://github.com/joyent/node/issues/7031
+    t.equal(path.normalize(opts.module_path),path.join(process.cwd(),"lib/binding/Release/test"));
+    var opts_toolset = versioning.evaluate(mock_package_json, {toolset:"custom-toolset"});
+    t.equal(opts_toolset.remote_path,"./test/v0.1.0/Release/0.1.0/custom-toolset/");
+    t.end();
 });
+
+test('should detect abi for node process', function(t) {
+    var mock_process_versions = {
+        node: '0.10.33',
+        v8: '3.14.5.9',
+        modules: '11',
+    };
+    var abi = versioning.get_node_abi('node',mock_process_versions);
+    t.equal(abi,'node-v11');
+    t.equal(versioning.get_runtime_abi('node',undefined),versioning.get_node_abi('node',process.versions));
+    t.end();
+});
+
+test('should detect abi for odd node target', function(t) {
+    var mock_process_versions = {
+        node: '0.11.1000000',
+        modules: 'bogus',
+    };
+    var abi = versioning.get_node_abi('node',mock_process_versions);
+    t.equal(abi,'node-v0.11.1000000');
+    t.end();
+});
+
+test('should detect abi for custom node target', function(t) {
+    var mock_process_versions = {
+        "node": '0.10.0',
+        "modules": '11',
+    };
+    t.equal(versioning.get_runtime_abi('node','0.10.0'),versioning.get_node_abi('node',mock_process_versions));
+    var mock_process_versions2 = {
+        "node": '0.8.0',
+        "v8": "3.11"
+    };
+    t.equal(versioning.get_runtime_abi('node','0.8.0'),versioning.get_node_abi('node',mock_process_versions2));
+    t.end();
+});
+
+test('should detect runtime for node-webkit and electron', function(t) {
+    var mock_process_versions = {
+        "electron": '0.37.3',
+    };
+    t.equal(versioning.get_process_runtime(mock_process_versions),'electron');
+    var mock_process_versions2 = {
+        "node": '0.8.0',
+    };
+    t.equal(versioning.get_process_runtime(mock_process_versions2),'node');
+    var mock_process_versions3 = {
+        "node-webkit": '0.37.3',
+    };
+    t.equal(versioning.get_process_runtime(mock_process_versions3),'node-webkit');
+    t.end();
+});
+
+test('should detect abi for electron runtime', function(t) {
+    t.equal(versioning.get_runtime_abi('electron','0.37.3'),versioning.get_electron_abi('electron','0.37.3'));
+    t.end();
+});
+
+test('should detect abi for node-webkit runtime', function(t) {
+    t.equal(versioning.get_runtime_abi('node-webkit','0.10.5'),versioning.get_node_webkit_abi('node-webkit','0.10.5'));
+    t.end();
+});
+
+test('should detect custom binary host from env', function(t) {
+    var mock_package_json = {
+        "name"   : "test",
+        "main"   : "test.js",
+        "version": "0.1.0",
+        "binary" : {
+            "module_name" : "test",
+            "module_path" : "./lib/binding/{configuration}/{toolset}/{name}",
+            "remote_path" : "./{name}/v{version}/{configuration}/{version}/{toolset}/",
+            "package_name": "{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz",
+            "host"        : "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
+        }
+    };
+    // mock npm_config_test_binary_host_mirror env
+    process.env.npm_config_test_binary_host_mirror = 'https://npm.taobao.org/mirrors/node-inspector/';
+    var opts = versioning.evaluate(mock_package_json, {});
+    t.equal(opts.host,'https://npm.taobao.org/mirrors/node-inspector/');
+    delete process.env.npm_config_test_binary_host_mirror;
+    t.end();
+});
+


### PR DESCRIPTION
While debugging #300 I suspected that the mocha tests might be behaving unpredictably. I wondered if porting to tape would resolve the issues in #300. They did not, but moving to `tape` seems ideal anyway (given https://macwright.org/2014/03/11/tape-is-cool.html). so I forged ahead on these.

Also solved in this PR along the way:

 - Solves one part of #276:
    - Because `After the nodejs series started releasing 2.x and above we've seen the ABI only get bumped with new major versions, predictably.` we now assume the ABI even when the exact minor.patch version is not stored in the abi crosswalk. This will avoid it needing to be updated as frequently (only for new major versions).
 - Applied better workaround in the appveyor.yml for https://github.com/mapbox/node-pre-gyp/issues/209
 - Started returning a non-zero error code with invalid usage (and added test for this).
 - Solves #302 and #300 by downgrading npm to avoid npm bugs