### PR TITLE
Support global host mirror with npm config

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -289,7 +289,7 @@ module.exports.evaluate = function(package_json,options) {
     // support global host mirror with npm config `--GLOBAL_binary_host_mirror`
     // instead of setting host mirror for each individual module you can set a global host mirror
     // useful for closed environments that only have access to a private artifactory (e.g CI machines)
-    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || process.env['npm_config_GLOBAL_binary_host_mirror'] || package_json.binary.host;
+    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || process.env.npm_config_GLOBAL_binary_host_mirror || package_json.binary.host;
     opts.host = fix_slashes(eval_template(host,opts));
     opts.module_path = eval_template(package_json.binary.module_path,opts);
     // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -286,7 +286,10 @@ module.exports.evaluate = function(package_json,options) {
     // support host mirror with npm config `--{module_name}_binary_host_mirror`
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
-    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || package_json.binary.host;
+    // support global host mirror with npm config `--GLOBAL_binary_host_mirror`
+    // instead of setting host mirror for each individual module you can set a global host mirror
+    // useful for closed environments that only have access to a private artifactory (e.g CI machines)
+    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || process.env['npm_config_GLOBAL_binary_host_mirror'] || package_json.binary.host;
     opts.host = fix_slashes(eval_template(host,opts));
     opts.module_path = eval_template(package_json.binary.module_path,opts);
     // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably


### PR DESCRIPTION
Support global host mirror with npm config `--GLOBAL_binary_host_mirror`
In addition to setting host mirror for each individual module, you can set a global host mirror.
It's useful for closed environments that only have access to a private artifactory (e.g CI machines)
I assume the priority should be in this order:
`--{module_name}_binary_host_mirror`
`--GLOBAL_binary_host_mirror`
`package_json.binary.host`
