### PR TITLE
support setting binary mirror host for all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,10 +576,14 @@ The options are visible in the code at <https://github.com/mapbox/node-pre-gyp/b
 
 S3 is broken in China for the well known reason.
 
-Using the `npm` config argument: `--{module_name}_binary_host_mirror` can download binary files through a mirror.
+Using the `npm` config argument: `--{module_name}_binary_host_mirror` can download binary files through a mirror, or `--binary_host_mirror` to specify the mirror for all pachages. 
 
 e.g.: Install [v8-profiler](https://www.npmjs.com/package/v8-profiler) from `npm`.
 
 ```bash
 $ npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
+```
+or omit the package name:
+```bash
+$ npm install v8-profile --binary_host_mirror=https://npm.taobao.org/mirrors
 ```

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -298,10 +298,16 @@ module.exports.evaluate = function(package_json,options) {
         module_main: package_json.main,
         toolset : options.toolset || '' // address https://github.com/mapbox/node-pre-gyp/issues/119
     };
-    // support host mirror with npm config `--{module_name}_binary_host_mirror`
+    // support host mirror with npm config:
+    //     1. npm install --`binary_host_mirror` to specify the mirror host for all modules
+    //     2. npm install --`{module_name}_binary_host_mirror` to specify the mirror host for the single module
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
-    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || package_json.binary.host;
+    var envPrefix = 'npm_config';
+    var envSuffix = 'binary_host_mirror';
+    var moduleMirrorHost = process.env[envPrefix + '_' + opts.module_name + '_' + envSuffix];
+    var globalMirrorHost = process.env[envPrefix + '_' + envSuffix];
+    var host = moduleMirrorHost || globalMirrorHost || package_json.binary.host;
     opts.host = fix_slashes(eval_template(host,opts));
     opts.module_path = eval_template(package_json.binary.module_path,opts);
     // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably


### PR DESCRIPTION
Using the `npm` config argument: `--{module_name}_binary_host_mirror` can download binary files through a mirror, or `--binary_host_mirror` to specify the mirror for all packages.