### PR TITLE
Keep compatibility with node v0.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ addons:
 
 env:
   matrix:
+   - NODE_VERSION="0.10"
    - NODE_VERSION="6" RETIRE=true
    - NODE_VERSION="4"
    - NODE_VERSION="5"
-   - NODE_VERSION="6"
    - NODE_VERSION="7"
    - NODE_VERSION="8"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,11 +19,11 @@ install:
   - npm config get
   # upgrade node-gyp to dodge 2013 compile issue present in the node gyp bundled with node v0.10
   # https://github.com/nodejs/node-gyp/issues/972#issuecomment-231055109
-  - IF "%nodejs_version:~0,1%"=="0" npm install node-gyp@3.x
+  - IF "%nodejs_version:~0,1%"=="0" npm install https://github.com/springmeyer/node-gyp/tarball/v3.x
   # upgrade node-gyp to dodge https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-307641388
   # and allow make node 4.x x86 builds work
   # https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
-  - IF "%nodejs_version:~0,1%"=="4" npm install node-gyp@3.x
+  - IF "%nodejs_version:~0,1%"=="4" npm install https://github.com/springmeyer/node-gyp/tarball/v3.x
   # downgrade npm to avoid multiple npm bugs:
   # for node v6 this dodges npm 3.10.10 bug whereby --nodedir/--dist-url is not passed to node-gyp (https://github.com/mapbox/node-pre-gyp/issues/300)
   # for all node x86 versions this dodges a mysterious ELIFECYCLE error: https://ci.appveyor.com/project/Mapbox/node-pre-gyp/build/1.0.582/job/b8q2nud6vkj0s6qo#L233

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-pre-gyp",
   "description": "Node.js native addon binary install tool",
-  "version" : "0.6.37",
+  "version": "0.6.37",
   "keywords": [
     "native",
     "addon",
@@ -24,7 +24,8 @@
     "nopt": "^4.0.1",
     "npmlog": "^4.0.2",
     "rc": "^1.1.7",
-    "request": "^2.81.0",
+    "request": "2.81.0",
+    "hawk":"3.1.3",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
     "tar": "^2.2.1",
@@ -44,7 +45,7 @@
     "noarg": true
   },
   "scripts": {
-    "pretest": "jshint test/build.test.js test/s3_setup.test.js test/versioning.test.js",
+    "pretest": "jshint test/build.test.js test/s3_setup.test.js test/versioning.test.js lib lib/util scripts bin/node-pre-gyp",
     "update-crosswalk": "node scripts/abi_crosswalk.js",
     "test": "jshint lib lib/util scripts bin/node-pre-gyp && tape test/*test.js"
   }


### PR DESCRIPTION
My plan is to keep compatibility with node v0.10.x in the 0.x series and bump to v1.x (dropping node v0.10.x support) after the merge of #299