### PR TITLE
get correct electron version when addon is running by child_process fork

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -79,7 +79,7 @@ function get_runtime_abi(runtime, target_version) {
     if (runtime === 'node-webkit') {
         return get_node_webkit_abi(runtime, target_version || process.versions['node-webkit']);
     } else if (runtime === 'electron') {
-        return get_electron_abi(runtime, target_version || process.versions.electron);
+        return get_electron_abi(runtime, target_version || process.versions.electron || process.env.ELECTRON_VERSION);
     } else {
         if (runtime != 'node') {
             throw new Error("Unknown Runtime: '" + runtime + "'");
@@ -261,7 +261,7 @@ function get_process_runtime(versions) {
     var runtime = 'node';
     if (versions['node-webkit']) {
         runtime = 'node-webkit';
-    } else if (versions.electron) {
+    } else if (versions.electron || process.env.ELECTRON_VERSION) {
         runtime = 'electron';
     }
     return runtime;

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -77,11 +77,26 @@ test('should detect runtime for node-webkit and electron', function(t) {
         "node-webkit": '0.37.3',
     };
     t.equal(versioning.get_process_runtime(mock_process_versions3),'node-webkit');
+
+    var mock_process_versions4 = {
+        "node": '0.8.0',
+    };
+    process.env.ELECTRON_VERSION = "9.9.9";
+    t.equal(versioning.get_process_runtime(mock_process_versions4),'electron');
+    delete process.env.ELECTRON_VERSION;
     t.end();
 });
 
 test('should detect abi for electron runtime', function(t) {
     t.equal(versioning.get_runtime_abi('electron','0.37.3'),versioning.get_electron_abi('electron','0.37.3'));
+
+    //ELECTRON_VERSION priority lower than others
+    var mock_process_versions = {
+        "node": '0.8.0',
+    };
+    process.env.ELECTRON_VERSION = "9.9.9";
+    t.equal(versioning.get_runtime_abi(versioning.get_process_runtime(mock_process_versions),'9.9.9'),versioning.get_electron_abi('electron','9.9.9'));
+    delete process.env.ELECTRON_VERSION;
     t.end();
 });
 


### PR DESCRIPTION
Because i can not direct get electron version in child_process, see [this](https://github.com/electron/electron/issues/9058). so `ELECTRON_RUN_AS_NODE ` is not [work](https://github.com/mapbox/node-pre-gyp/pull/279).
We can pass some process env to fork method like this:
```
// run in electron main process
const env = {...process.env,ELECTRON_VERSION:process.versions.electron};
const p = require( 'child_process').fork(`${ __dirname }/child_process.js`,[],{env:env});
```