### PR TITLE
fix: update `request` and `hawk` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,15 +20,17 @@
   "bin": "./bin/node-pre-gyp",
   "main": "./lib/node-pre-gyp.js",
   "dependencies": {
+    "detect-libc": "^1.0.2",
+    "hawk": "^7.0.7",
     "mkdirp": "^0.5.1",
     "nopt": "^4.0.1",
     "npmlog": "^4.0.2",
     "rc": "^1.1.7",
     "request": "2.81.0",
     "hawk":"3.1.3",
+    "request": "^2.83.0",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
-    "detect-libc": "^1.0.2",
     "tar": "^2.2.1",
     "tar-pack": "^3.4.0"
   },


### PR DESCRIPTION
Right now, node-pre-gyp is causing `nsp` to barf because it is depending on an old version of `hoek` via the modules `hawk` and `request`

```
nsp check
(+) 2 vulnerabilities found
┌────────────┬────────────────────────────────────────────────────────────────────┐
│            │ Prototype pollution attack                                         │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Name       │ hoek                                                               │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ CVSS       │ 4 (Medium)                                                         │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Installed  │ 2.16.3                                                             │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Vulnerable │ <= 4.2.0 || >= 5.0.0 < 5.0.3                                       │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Patched    │ > 4.2.0 < 5.0.0 || >= 5.0.3                                        │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Path       │ node-pre-gyp@0.6.40 > request@2.81.0 > hawk@3.1.3 > hoek@2.16.3    │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ More Info  │ https://nodesecurity.io/advisories/566                             │
└────────────┴────────────────────────────────────────────────────────────────────┘

┌────────────┬────────────────────────────────────────────────────────────────────┐
│            │ Prototype pollution attack                                         │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Name       │ hoek                                                               │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ CVSS       │ 4 (Medium)                                                         │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Installed  │ 2.16.3                                                             │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Vulnerable │ <= 4.2.0 || >= 5.0.0 < 5.0.3                                       │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Patched    │ > 4.2.0 < 5.0.0 || >= 5.0.3                                        │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Path       │ node-pre-gyp@0.6.40 > hawk@3.1.3 > hoek@2.16.3                     │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ More Info  │ https://nodesecurity.io/advisories/566                             │
└────────────┴────────────────────────────────────────────────────────────────────┘
```

This PR will peg the `hawk` and `request` at versions which pull in an updated `hoek` package.