### PR TITLE
Have needle follow redirects

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -32,7 +32,8 @@ function download(uri,opts,callback) {
         uri: uri.replace('+','%2B'),
         headers: {
           'User-Agent': 'node-pre-gyp (v' + npgVersion + ', ' + envVersionInfo + ')'
-        }
+        },
+        follow_max: 10,
     };
 
     if (opts.cafile) {
@@ -105,7 +106,10 @@ function place_binary(from,to,opts,callback) {
         });
 
         req.on('response', function(res) {
-            if (res.statusCode !== 200) {
+           if (res.statusCode === 302) {
+             return;
+           }
+           if (res.statusCode !== 200) {
                 badDownload = true;
                 var err = new Error(res.statusCode + ' status code downloading tarball ' + from);
                 err.statusCode = res.statusCode;

--- a/lib/install.js
+++ b/lib/install.js
@@ -105,8 +105,9 @@ function place_binary(from,to,opts,callback) {
             }
         });
 
-        req.on('response', function(res) {
-           if (res.statusCode === 302) {
+      req.on('response', function(res) {
+           // ignore redirects, needle handles these automatically.
+           if (res.headers.hasOwnProperty('location') && res.headers.location !== '') {
              return;
            }
            if (res.statusCode !== 200) {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
     "tar": "^4"
   },
   "devDependencies": {
-    "tape": "^4.6.3",
     "aws-sdk": "^2.28.0",
+    "jshint": "^2.9.5",
+    "nock": "^9.2.3",
     "retire": "^1.2.12",
-    "jshint": "^2.9.5"
+    "tape": "^4.6.3"
   },
   "jshintConfig": {
     "node": true,
@@ -45,7 +46,7 @@
     "noarg": true
   },
   "scripts": {
-    "pretest": "jshint test/build.test.js test/s3_setup.test.js test/versioning.test.js lib lib/util scripts bin/node-pre-gyp",
+    "pretest": "jshint test/build.test.js test/s3_setup.test.js test/versioning.test.js test/fetch.test.js lib lib/util scripts bin/node-pre-gyp",
     "update-crosswalk": "node scripts/abi_crosswalk.js",
     "test": "jshint lib lib/util scripts bin/node-pre-gyp && tape test/*test.js"
   }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -10,7 +10,7 @@ test('should follow redirects', function(t) {
 
   // Mock an HTTP redirect
   var n = nock('https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com')
-      .get('/app1-v0.1.0-node-v48-darwin-x64.tar.gz')
+      .get(/\/app1-v0.1.0-node-v\d+-\S+.tar.gz/)
       .reply(302, '', {
         'Location': 'https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com/otherapp.tar.gz'
       })

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var test = require('tape');
+var nock = require('nock');
+var install = require('../lib/install.js');
+
+test('should follow redirects', function(t) {
+  // Dummy tar.gz data, contains a blank directory.
+  var targz = 'H4sICPr8u1oCA3kudGFyANPTZ6A5MDAwMDc1VQDTZhAaCGA0hGNobGRqZm5uZmxupGBgaGhiZsKgYMpAB1BaXJJYBHRKYk5pcioedeUZqak5+D2J5CkFhlEwCkbBKBjkAAAyG1ofAAYAAA==';
+
+  // Mock an HTTP redirect
+  var n = nock('https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com')
+      .get('/app1-v0.1.0-node-v48-darwin-x64.tar.gz')
+      .reply(302, '', {
+        'Location': 'https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com/otherapp.tar.gz'
+      })
+      .get('/otherapp.tar.gz')
+      .reply(200, Buffer.from(targz, 'base64'));
+
+  var opts = {
+    opts: {
+      'build-from-source': false,
+      'update-binary': true
+    }
+  };
+
+  process.chdir('test/app1');
+
+  install(opts, [], function(err) {
+    t.ifError(err); // Worked fine
+    t.ok(n.isDone()); // All mocks consumed
+    t.end();
+  });
+
+});
+


### PR DESCRIPTION
Redirect following for binary installations broke with the [switch to needle](https://github.com/mapbox/node-pre-gyp/issues/350). This replaces the functionality.

Not having a redirect means (at least in my case) that pre-built binaries that are registered as part of a Github release cannot be downloaded.

This addresses #359