### PR TITLE
Allow for single-level module_path when packing

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -33,15 +33,18 @@ function _package(gyp, argv, callback) {
             return true;
         };
         mkdirp(path.dirname(tarball),function(err) {
-            from = path.dirname(from);
             if (err) return callback(err);
             packlist({ path: from }).then(function(files) {
+                var base = path.basename(from);
+                files = files.map(function(file) {
+                    return path.join(base, file);
+                });
                 tar.create({
                     portable: true,
                     gzip: true,
                     onentry: filter_func,
                     file: tarball,
-                    cwd: from
+                    cwd: path.dirname(from)
                 }, files, function(err) {
                     if (err)  console.error('['+package_json.name+'] ' + err.message);
                     else log.info('package','Binary staged at "' + tarball + '"');

--- a/test/app8/.gitignore
+++ b/test/app8/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+build/
+lib/
+node_modules
+npm-debug.log

--- a/test/app8/README.md
+++ b/test/app8/README.md
@@ -1,0 +1,3 @@
+# Test app
+
+Demonstrates a simpler configuration that uses node-pre-gyp.

--- a/test/app8/app8.cc
+++ b/test/app8/app8.cc
@@ -1,0 +1,38 @@
+// v8
+#include <v8.h>
+
+// node.js
+#include <node.h>
+#include <node_version.h>
+
+#if (NODE_MODULE_VERSION > 0x000B)
+
+    static void get_hello(const v8::FunctionCallbackInfo<v8::Value>& args)
+    {
+        v8::HandleScope scope(v8::Isolate::GetCurrent());
+        args.GetReturnValue().Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),"hello"));
+    }
+
+#else
+
+    static v8::Handle<v8::Value> get_hello(const v8::Arguments& args)
+    {
+        v8::HandleScope scope;
+        return scope.Close(v8::String::New("hello"));
+    }
+
+#endif
+
+extern "C" {
+    static void start(v8::Handle<v8::Object> target) {
+#if (NODE_MODULE_VERSION > 0x000B)
+        v8::HandleScope scope(v8::Isolate::GetCurrent());
+#else
+        v8::HandleScope scope;
+#endif
+        NODE_SET_METHOD(target, "hello", get_hello);
+    }
+}
+
+NODE_MODULE(app8, start)
+

--- a/test/app8/binding.gyp
+++ b/test/app8/binding.gyp
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    {
+      "target_name": "<(module_name)",
+      "sources": [ "<(module_name).cc" ],
+      "product_dir": "<(module_path)",
+      "xcode_settings": {
+        "MACOSX_DEPLOYMENT_TARGET":"10.9",
+        "CLANG_CXX_LIBRARY": "libc++"
+      }
+     }
+  ]
+}

--- a/test/app8/index.js
+++ b/test/app8/index.js
@@ -1,0 +1,6 @@
+var binary = require('node-pre-gyp');
+var path = require('path')
+var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
+var binding = require(binding_path);
+
+require('assert').equal(binding.hello(),"hello");

--- a/test/app8/package.json
+++ b/test/app8/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "node-pre-gyp-test-app8",
+    "author": "Dane Springmeyer <springmeyer>",
+    "description": "node-pre-gyp test",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/mapbox/node-pre-gyp.git"
+    },
+    "license": "BSD-3-Clause",
+    "version": "0.1.0",
+    "main": "./index.js",
+    "binary": {
+        "module_name": "app8",
+        "module_path": "./lib",
+        "host": "https://node-pre-gyp-tests.s3-us-west-1.amazonaws.com"
+    },
+    "scripts": {
+        "install": "node-pre-gyp install --fallback-to-build",
+        "test": "node index.js"
+    }
+}

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -12,6 +12,8 @@ var versioning = require('../lib/util/versioning.js');
 var tar = require('tar');
 
 var localVer = [versioning.get_runtime_abi('node'), process.platform, process.arch].join('-');
+var SOEXT = process.platform === 'darwin' ? 'dylib': 'so';
+
 // The list of different sample apps that we use to test
 var apps = [
     {
@@ -37,7 +39,7 @@ var apps = [
     {
         'name': 'app4',
         'args': '',
-        'files': [path.join(localVer, 'app4.node'), path.join(localVer, 'lib.target', 'mylib.dylib')]
+        'files': [path.join(localVer, 'app4.node'), path.join(localVer, 'lib.target', 'mylib.' + SOEXT)]
     },
     {
         'name': 'app7',

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -8,8 +8,10 @@ var rm = require('rimraf');
 var path = require('path');
 var getPrevious = require('./target_version.util.js');
 var napi = require ('../lib/util/napi.js');
+var versioning = require('../lib/util/versioning.js');
 var tar = require('tar');
 
+var localVer = [versioning.get_runtime_abi('node'), process.platform, process.arch].join('-');
 // The list of different sample apps that we use to test
 var apps = [
     {
@@ -30,12 +32,12 @@ var apps = [
     {
         'name': 'app3',
         'args': '',
-        'files': ['node-v48-darwin-x64/app3.node']
+        'files': [path.join(localVer, 'app3.node')]
     },
     {
         'name': 'app4',
         'args': '',
-        'files': ['node-v48-darwin-x64/app4.node', 'node-v48-darwin-x64/lib.target/mylib.dylib']
+        'files': [path.join(localVer, 'app4.node'), path.join(localVer, 'lib.target', 'mylib.dylib')]
     },
     {
         'name': 'app7',


### PR DESCRIPTION
Prior to 0.7.1, a module_path of `./lib` would result in a package containing files like this (using `test/app8` as an example):

    lib/app8.node

The switch to tar 3 in 0.7.1 causes the same package to end up like this:

    package.json
    app8.cc
    binding.gyp
    index.js
    README.md
    lib/app8.node

which causes a problem during remote binary installation:

    node-pre-gyp ERR! Pre-built binaries not installable for PACKAGE@0.0.1 and node@8.3.0 (node-v57 ABI, glibc) (falling back to source compile with node-gyp)
    node-pre-gyp ERR! Hit error ENOTDIR: Cannot cd into '..dirs/package/lib'

This commit fixes this problem and allows for single-level module_path values.

Fixes #364 