### PR TITLE
updates to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ addons:
 
 env:
   matrix:
-   - NODE_VERSION="5"
    - NODE_VERSION="6"
-   - NODE_VERSION="7"
    - NODE_VERSION="8"
    - NODE_VERSION="9"
    - NODE_VERSION="10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ addons:
 
 env:
   matrix:
-   - NODE_VERSION="6" RETIRE=true
-   - NODE_VERSION="4"
    - NODE_VERSION="5"
+   - NODE_VERSION="6"
    - NODE_VERSION="7"
    - NODE_VERSION="8"
    - NODE_VERSION="9"
+   - NODE_VERSION="10"
 
 before_install:
 - if [[ $(uname -s) == 'Linux' ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
   - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
   - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@2 -g
   - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@2 -g
+  - IF "%nodejs_version:~0,2%" EQU "10" npm install npm@2 -g
   - npm config get
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,10 @@ shallow_clone: true
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
+  # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
+  - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@2 -g
   - npm config get
   - node --version
   - npm --version
@@ -24,11 +28,6 @@ install:
   - IF /I "%PLATFORM%" == "x86" SET PATH=C:\python27;%PATH%
   - IF /I "%PLATFORM%" == "x64" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - IF /I "%PLATFORM%" == "x86" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
-  # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@6 -g
-  - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@6 -g
-  - IF "%nodejs_version:~0,1%" EQU "10" npm install npm@6 -g
   - npm install
   - npm test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - IF /I "%PLATFORM%" == "x86" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
   - npm install
   # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  - IF "%nodejs_version:~0,1%" GEQ "6" npm install npm@2 -g
+  # - IF "%nodejs_version:~0,1%" GEQ "6" npm install npm@2 -g
   - npm test
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,6 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
   - npm config get
-  # upgrade node-gyp to dodge https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-307641388
-  # and allow make node 4.x x86 builds work
-  - IF "%nodejs_version:~0,1%" EQU "4" npm install node-gyp@3.x
   - node --version
   - npm --version
   - node -e "console.log(process.arch);"
@@ -27,12 +24,12 @@ install:
   - IF /I "%PLATFORM%" == "x86" SET PATH=C:\python27;%PATH%
   - IF /I "%PLATFORM%" == "x64" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - IF /I "%PLATFORM%" == "x86" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
-  - npm install
   # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  - IF "%nodejs_version:~0,1%" EQU "4" npm install npm@2 -g
   - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
   - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@6 -g
+  - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@6 -g
   - IF "%nodejs_version:~0,1%" EQU "10" npm install npm@6 -g
+  - npm install
   - npm test
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: 6
     - nodejs_version: 8
     - nodejs_version: 9
+    - nodejs_version: 10
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,10 @@ install:
   - IF /I "%PLATFORM%" == "x86" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
   - npm install
   # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  # - IF "%nodejs_version:~0,1%" GEQ "6" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQ "4" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQ "6" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQ "8" npm install npm@6 -g
+  - IF "%nodejs_version:~0,1%" EQ "10" npm install npm@6 -g
   - npm test
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,10 +29,10 @@ install:
   - IF /I "%PLATFORM%" == "x86" CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
   - npm install
   # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  - IF "%nodejs_version:~0,1%" EQ "4" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQ "6" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQ "8" npm install npm@6 -g
-  - IF "%nodejs_version:~0,1%" EQ "10" npm install npm@6 -g
+  - IF "%nodejs_version:~0,1%" EQU "4" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
+  - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@6 -g
+  - IF "%nodejs_version:~0,1%" EQU "10" npm install npm@6 -g
   - npm test
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - nodejs_version: 4
     - nodejs_version: 6
     - nodejs_version: 8
     - nodejs_version: 9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,6 @@ shallow_clone: true
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
-  # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@2 -g
-  - IF "%nodejs_version:~0,2%" EQU "10" npm install npm@2 -g
   - npm config get
   - node --version
   - npm --version

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -193,7 +193,7 @@ test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.arg
     });
 });
 
-// NOTE: currently fails with npm v3.x on windows (hench downgrade in appveyor.yml)
+// NOTE: currently fails with npm v3.x on windows (hence downgrade in appveyor.yml)
 test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
     run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
         console.log('ERROR', err);

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -196,6 +196,9 @@ test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.arg
 // NOTE: currently fails with npm v3.x on windows (hench downgrade in appveyor.yml)
 test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
     run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
+        console.log('ERROR', err);
+        console.log('STDOUT', stdout);
+        console.log('STDERR', stderr);
         t.ok(err, 'Expected command to fail');
         t.stringContains(stderr,"common.gypi not found");
         t.end();
@@ -232,6 +235,9 @@ test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.ar
 
 test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
     run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
+        console.log('ERROR', err);
+        console.log('STDOUT', stdout);
+        console.log('STDERR', stderr);
         t.ok(err, 'Expected command to fail');
         t.end();
     });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -196,9 +196,6 @@ test(app.name + ' passes --nodedir down to node-gyp via node-pre-gyp ' + app.arg
 // NOTE: currently fails with npm v3.x on windows (hence downgrade in appveyor.yml)
 test(app.name + ' passes --nodedir down to node-gyp via npm' + app.args, function(t) {
     run('npm', 'install', '--build-from-source --nodedir=invalid-value', app, {}, function(err,stdout,stderr) {
-        console.log('ERROR', err);
-        console.log('STDOUT', stdout);
-        console.log('STDERR', stderr);
         t.ok(err, 'Expected command to fail');
         t.stringContains(stderr,"common.gypi not found");
         t.end();
@@ -235,9 +232,6 @@ test(app.name + ' passes --dist-url down to node-gyp via node-pre-gyp ' + app.ar
 
 test(app.name + ' passes --dist-url down to node-gyp via npm ' + app.args, function(t) {
     run('npm', 'install', '--build-from-source --ensure=false --dist-url=invalid-value', app, {}, function(err,stdout,stderr) {
-        console.log('ERROR', err);
-        console.log('STDOUT', stdout);
-        console.log('STDERR', stderr);
         t.ok(err, 'Expected command to fail');
         t.end();
     });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -35,6 +35,14 @@ var apps = [
                     'binding/app1.lib',
                     'binding/app1.map',
                     'binding/app1.node'
+                ],
+                'node-v64': [
+                    'binding/app1.exp',
+                    'binding/app1.iobj',
+                    'binding/app1.ipdb',
+                    'binding/app1.lib',
+                    'binding/app1.map',
+                    'binding/app1.node'
                 ]
             }
         }
@@ -71,7 +79,15 @@ var apps = [
                     'node-pre-gyp-test-app2/app2.ipdb',
                     'node-pre-gyp-test-app2/app2.lib',
                     'node-pre-gyp-test-app2/app2.map',
-                    'node-pre-gyp-test-app2/app2.node' 
+                    'node-pre-gyp-test-app2/app2.node'
+                ],
+                'node-v64': [
+                    'node-pre-gyp-test-app2/app2.exp',
+                    'node-pre-gyp-test-app2/app2.iobj',
+                    'node-pre-gyp-test-app2/app2.ipdb',
+                    'node-pre-gyp-test-app2/app2.lib',
+                    'node-pre-gyp-test-app2/app2.map',
+                    'node-pre-gyp-test-app2/app2.node'
                 ]
             }
         }
@@ -89,6 +105,14 @@ var apps = [
                     [localVer, 'app3.node'].join('/')
                 ],
                 'node-v59': [
+                    [localVer, 'app3.exp'].join('/'),
+                    [localVer, 'app3.iobj'].join('/'),
+                    [localVer, 'app3.ipdb'].join('/'),
+                    [localVer, 'app3.lib'].join('/'),
+                    [localVer, 'app3.map'].join('/'),
+                    [localVer, 'app3.node'].join('/'),
+                ],
+                'node-v64': [
                     [localVer, 'app3.exp'].join('/'),
                     [localVer, 'app3.iobj'].join('/'),
                     [localVer, 'app3.ipdb'].join('/'),
@@ -124,6 +148,14 @@ var apps = [
                     'lib/app8.node'
                 ],
                 'node-v59': [
+                    'lib/app8.exp',
+                    'lib/app8.iobj',
+                    'lib/app8.ipdb',
+                    'lib/app8.lib',
+                    'lib/app8.map',
+                    'lib/app8.node'
+                ],
+                'node-v64': [
                     'lib/app8.exp',
                     'lib/app8.iobj',
                     'lib/app8.ipdb',
@@ -338,7 +370,7 @@ apps.forEach(function(app) {
                         if (app.files[process.platform].hasOwnProperty(nodever)) {
                             files = app.files[process.platform][nodever];
                         } else if (app.files[process.platform].hasOwnProperty('base')) {
-                            files = app.files[process.platform].base; 
+                            files = app.files[process.platform].base;
                         } else {
                             files = app.files[process.platform];
                         }

--- a/test/run.util.js
+++ b/test/run.util.js
@@ -46,7 +46,7 @@ function run(prog,command,args,app,opts,cb) {
 
     // unless explicitly provided, lets execute the command inside the app specific directory
     if (!opts.cwd) {
-        final_cmd += ' -C ' + path.join(__dirname,app.name);
+        opts.cwd = path.join(__dirname,app.name);
     }
     // avoid breakage when compiling with clang++ and node v0.10.x
     // This is harmless to add for other versions and platforms


### PR DESCRIPTION
This updates the travis matrix to:

* remove the RETIRE warnings from CI builds (but keep node v6 tests)
* remove Node v4 testing (Node v4 is EOL on April 30th https://github.com/nodejs/Release)
* add Node v10 builds

cc @springmeyer for review