### PR TITLE
Dane debug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,14 +16,6 @@ shallow_clone: true
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
-  - SET PATH=bin\;%PATH%
-  - npm -C test/app1/ install || true
-  # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
-  - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@2 -g
-  - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@2 -g
-  - IF "%nodejs_version:~0,2%" EQU "10" npm install npm@2 -g
-  - npm -C test/app1/ install || true
   - npm config get
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,14 @@ shallow_clone: true
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - ps: Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
+  - SET PATH=bin\;%PATH%
+  - npm -C test/app1/ install || true
   # workaround https://github.com/mapbox/node-pre-gyp/issues/300#issuecomment-328179994
   - IF "%nodejs_version:~0,1%" EQU "6" npm install npm@2 -g
   - IF "%nodejs_version:~0,1%" EQU "8" npm install npm@2 -g
   - IF "%nodejs_version:~0,1%" EQU "9" npm install npm@2 -g
   - IF "%nodejs_version:~0,2%" EQU "10" npm install npm@2 -g
+  - npm -C test/app1/ install || true
   - npm config get
   - node --version
   - npm --version

--- a/test/run.util.js
+++ b/test/run.util.js
@@ -46,7 +46,7 @@ function run(prog,command,args,app,opts,cb) {
 
     // unless explicitly provided, lets execute the command inside the app specific directory
     if (!opts.cwd) {
-        final_cmd += ' -C ' + path.join(__dirname,app.name);
+        opts.cwd = path.join(__dirname,app.name);
     }
     // avoid breakage when compiling with clang++ and node v0.10.x
     // This is harmless to add for other versions and platforms


### PR DESCRIPTION
Looks like npm >= 3.x removed the support for `-C <path to working directory>`. This works around the change by moving to pass `{cwd : <path to working directory>}` in the options to the child process rather than the command line flag.

Fixes https://github.com/mapbox/node-pre-gyp/issues/300