### PR TITLE
change needle "error" event to "err" event, fix "Completion callback never invoked!"

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -94,7 +94,7 @@ function place_binary(from,to,opts,callback) {
             extractCount++;
         }
 
-        req.on('error', function(err) {
+        req.on('err', function(err) {
             badDownload = true;
             return callback(err);
         });


### PR DESCRIPTION
fixbug: if network unreachable, will crash with "Completion callback never invoked!"
needle "error" event called "err".