### PR TITLE
fix: reinstall script not working

### DIFF
--- a/lib/reinstall.js
+++ b/lib/reinstall.js
@@ -10,7 +10,7 @@ var napi = require('./util/napi.js');
 function rebuild (gyp, argv, callback) {
   var package_json = JSON.parse(fs.readFileSync('./package.json'));
   var installArgs = [];
-  var napi_build_version = napi.get_best_napi_version(package_json);
+  var napi_build_version = napi.get_best_napi_build_version(package_json);
   if (napi_build_version != null) installArgs = [ napi.get_command_arg (napi_build_version) ];
   gyp.todo.unshift(
       { name: 'clean', args: [] },


### PR DESCRIPTION
While trying to get GRPC for electron 2, I've encountered following bug:

Command:
`npx node-pre-gyp --target=2.0.1 --runtime=electron --fallback-to-build --directory node_modules/grpc reinstall`

Output:
```
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.10.0
node-pre-gyp info using node@10.2.1 | darwin | x64
node-pre-gyp info chdir node_modules/grpc
napi.get_best_napi_version is not a function
```

After doing some research, I've found out that in `/lib/util/napi.js` there is no `get_best_napi_version()`, only `get_best_napi_build_version()`. I've replaced it and finaly got GRPC :)

Signed-off-by: Vyacheslav Bikbaev <la.sintez@gmail.com>