### PR TITLE
Fix issue with `close` event always being emitted

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -92,6 +92,7 @@ function place_binary(from,to,opts,callback) {
         if (!req) return callback(new Error("empty req"));
         var badDownload = false;
         var extractCount = 0;
+        var hasResponse = false;
         var tar = require('tar');
 
         function afterTarball(err) {
@@ -122,7 +123,7 @@ function place_binary(from,to,opts,callback) {
         });
 
         req.on('close', function () {
-            if (extractCount === 0) {
+            if (!hasResponse) {
                 return callback(new Error('Connection closed while downloading tarball file'));
             }
         });
@@ -132,6 +133,7 @@ function place_binary(from,to,opts,callback) {
            if (http_get.type === 'needle' && res.headers.hasOwnProperty('location') && res.headers.location !== '') {
                return;
            }
+           hasResponse = true;
            if (res.statusCode !== 200) {
                 badDownload = true;
                 var err = new Error(res.statusCode + ' status code downloading tarball ' + from);


### PR DESCRIPTION
This addresses a changed behaviour in Node 10, resulting
from the fact that the `close` event is always being emitted
now. This would have lead to the `place_binary()` callback being
called twice when the HTTP request failed (with e.g. a 404).

Refs: https://github.com/nodejs/node/issues/21063
Fixes: https://github.com/mapbox/node-pre-gyp/issues/391

Edit: The original breakage was reverted in Node 10.8.0 since it was an unintentional semver-major change, but *will* be kept for Node 11+.