### PR TITLE
Simplify use of binaries off a local artifactory

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -309,7 +309,7 @@ module.exports.evaluate = function(package_json,options,napi_build_version) {
     // support host mirror with npm config `--{module_name}_binary_host_mirror`
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
-    var host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || package_json.binary.host;
+    var host = process.env.npm_config_binary_host_mirror || process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || package_json.binary.host;
     opts.host = fix_slashes(eval_template(host,opts));
     opts.module_path = eval_template(package_json.binary.module_path,opts);
     // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably
@@ -322,6 +322,9 @@ module.exports.evaluate = function(package_json,options,napi_build_version) {
     }
     opts.module = path.join(opts.module_path,opts.module_name + '.node');
     opts.remote_path = package_json.binary.remote_path ? drop_double_slashes(fix_slashes(eval_template(package_json.binary.remote_path,opts))) : default_remote_path;
+    if (opts.remote_path.charAt(0) == "/") {
+        opts.remote_path = opts.remote_path.substr(1);
+    }
     var package_name = package_json.binary.package_name ? package_json.binary.package_name : default_package_name;
     opts.package_name = eval_template(package_name,opts);
     opts.staged_tarball = path.join('build/stage',opts.remote_path,opts.package_name);

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -264,7 +264,7 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' configures with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'configure', '--loglevel=info -- --foo=bar', app, {}, function(err,stdout,stderr) {
+            run('node-pre-gyp', 'configure', '--loglevel=info --foo=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
                 t.ok(stderr.search(/(gyp info spawn args).*(--foo=bar)/) > -1);
                 t.end();
@@ -272,31 +272,14 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' builds with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'clean', '', app, {}, function(err) {
+            run('node-pre-gyp', 'rebuild', '--loglevel=info --FOO=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
-                run('node-pre-gyp', 'build', '--loglevel=info -- --FOO=bar', app, {}, function(err,stdout,stderr) {
-                    t.ifError(err);
-                    t.ok(stderr.search(/(gyp info spawn args).*(--FOO=bar)/) > -1);
-                    if (process.platform == 'win32') {
-                        if (app.args.indexOf('--debug') > -1) {
-                            t.stringContains(stdout,'Debug/'+app.name+'.node');
-                        } else {
-                            t.stringContains(stdout,'Release/'+app.name+'.node');
-                        }
-                    }
-                    t.end();
-                });
-            });
-        });
-
-        test(app.name + ' builds ' + app.args, function(t) {
-            run('node-pre-gyp', 'rebuild', '--fallback-to-build --loglevel=error', app, {}, function(err,stdout,stderr) {
-                t.ifError(err);
+                t.ok(stderr.search(/(gyp info spawn args).*(--FOO=bar)/) > -1);
                 if (process.platform == 'win32') {
                     if (app.args.indexOf('--debug') > -1) {
-                        t.stringContains(stdout,'Debug/'+app.name+'.node');
+                        t.stringContains(stdout,'Debug\\'+app.name+'.node');
                     } else {
-                        t.stringContains(stdout,'Release/'+app.name+'.node');
+                        t.stringContains(stdout,'Release\\'+app.name+'.node');
                     }
                 }
                 t.end();

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -263,6 +263,7 @@ apps.forEach(function(app) {
             });
         });
 
+        /* wait for https://github.com/nodejs/node-gyp/pull/1540
         test(app.name + ' configures with unparsed options ' + app.args, function(t) {
             run('node-pre-gyp', 'configure', '--loglevel=info -- -Dfoo=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
@@ -275,6 +276,21 @@ apps.forEach(function(app) {
             run('node-pre-gyp', 'rebuild', '--loglevel=info -- -DFOO=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
                 t.ok(stderr.search(/(gyp info spawn args).*(-DFOO=bar)/) > -1);
+                if (process.platform == 'win32') {
+                    if (app.args.indexOf('--debug') > -1) {
+                        t.stringContains(stdout,'Debug\\'+app.name+'.pdb');
+                    } else {
+                        t.stringContains(stdout,'Release\\'+app.name+'.pdb');
+                    }
+                }
+                t.end();
+            });
+        });*/
+
+        test(app.name + ' builds ' + app.args, function(t) {
+            run('node-pre-gyp', 'rebuild', '--loglevel=info', app, {}, function(err,stdout,stderr) {
+                t.ifError(err);
+                t.ok(stderr.search(/(gyp info spawn args).*(binding\.gyp)/) > -1);
                 if (process.platform == 'win32') {
                     if (app.args.indexOf('--debug') > -1) {
                         t.stringContains(stdout,'Debug\\'+app.name+'.pdb');

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -264,17 +264,17 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' configures with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'configure', '--loglevel=info -- --foo=bar', app, {}, function(err,stdout,stderr) {
+            run('node-pre-gyp', 'configure', '--loglevel=info -- -Dfoo=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
-                t.ok(stderr.search(/(gyp info spawn args).*(--foo=bar)/) > -1);
+                t.ok(stderr.search(/(gyp info spawn args).*(-Dfoo=bar)/) > -1);
                 t.end();
             });
         });
 
         test(app.name + ' builds with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'rebuild', '--loglevel=info -- --FOO=bar', app, {}, function(err,stdout,stderr) {
+            run('node-pre-gyp', 'rebuild', '--loglevel=info -- -DFOO=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
-                t.ok(stderr.search(/(gyp info spawn args).*(--FOO=bar)/) > -1);
+                t.ok(stderr.search(/(gyp info spawn args).*(-DFOO=bar)/) > -1);
                 if (process.platform == 'win32') {
                     if (app.args.indexOf('--debug') > -1) {
                         t.stringContains(stdout,'Debug\\'+app.name+'.pdb');

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -276,8 +276,7 @@ apps.forEach(function(app) {
             // and build only works with FOO=bar
             run('node-pre-gyp', 'clean', '', app, {}, function(err) {
                 t.ifError(err);
-                var propertyPrefix = (process.platform === 'win32') ? '/p:' : '';
-                run('node-pre-gyp', 'build', '--loglevel=info -- ' + propertyPrefix + 'FOO=bar', app, {}, function(err,stdout,stderr) {
+                run('node-pre-gyp', 'build', '--loglevel=info -- -DFOO=bar', app, {}, function(err,stdout,stderr) {
                     t.ifError(err);
                     t.ok(stderr.search(/(gyp info spawn args).*(FOO=bar)/) > -1);
                     if (process.platform !== 'win32') {

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -264,7 +264,7 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' configures with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'configure', '--loglevel=info --foo=bar', app, {}, function(err,stdout,stderr) {
+            run('node-pre-gyp', 'configure', '--loglevel=info -- --foo=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
                 t.ok(stderr.search(/(gyp info spawn args).*(--foo=bar)/) > -1);
                 t.end();
@@ -272,14 +272,14 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' builds with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'rebuild', '--loglevel=info --FOO=bar', app, {}, function(err,stdout,stderr) {
+            run('node-pre-gyp', 'rebuild', '--loglevel=info -- --FOO=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
                 t.ok(stderr.search(/(gyp info spawn args).*(--FOO=bar)/) > -1);
                 if (process.platform == 'win32') {
                     if (app.args.indexOf('--debug') > -1) {
-                        t.stringContains(stdout,'Debug\\'+app.name+'.node');
+                        t.stringContains(stdout,'Debug\\'+app.name+'.pdb');
                     } else {
-                        t.stringContains(stdout,'Release\\'+app.name+'.node');
+                        t.stringContains(stdout,'Release\\'+app.name+'.pdb');
                     }
                 }
                 t.end();

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -264,22 +264,20 @@ apps.forEach(function(app) {
         });
 
         test(app.name + ' configures with unparsed options ' + app.args, function(t) {
-            run('node-pre-gyp', 'configure', '--loglevel=info -- -Dfoo=bar', app, {}, function(err,stdout,stderr) {
+            run('node-pre-gyp', 'configure', '--loglevel=info -- --foo=bar', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
-                t.ok(stderr.search(/(gyp info spawn args).*(-Dfoo=bar)/) > -1);
+                t.ok(stderr.search(/(gyp info spawn args).*(--foo=bar)/) > -1);
                 t.end();
             });
         });
 
         test(app.name + ' builds with unparsed options ' + app.args, function(t) {
-            // clean and build as separate steps here because configure only works with -Dfoo=bar
-            // and build only works with FOO=bar
             run('node-pre-gyp', 'clean', '', app, {}, function(err) {
                 t.ifError(err);
-                run('node-pre-gyp', 'build', '--loglevel=info -- -DFOO=bar', app, {}, function(err,stdout,stderr) {
+                run('node-pre-gyp', 'build', '--loglevel=info -- --FOO=bar', app, {}, function(err,stdout,stderr) {
                     t.ifError(err);
-                    t.ok(stderr.search(/(gyp info spawn args).*(FOO=bar)/) > -1);
-                    if (process.platform !== 'win32') {
+                    t.ok(stderr.search(/(gyp info spawn args).*(--FOO=bar)/) > -1);
+                    if (process.platform == 'win32') {
                         if (app.args.indexOf('--debug') > -1) {
                             t.stringContains(stdout,'Debug/'+app.name+'.node');
                         } else {
@@ -294,7 +292,7 @@ apps.forEach(function(app) {
         test(app.name + ' builds ' + app.args, function(t) {
             run('node-pre-gyp', 'rebuild', '--fallback-to-build --loglevel=error', app, {}, function(err,stdout,stderr) {
                 t.ifError(err);
-                if (process.platform !== 'win32') {
+                if (process.platform == 'win32') {
                     if (app.args.indexOf('--debug') > -1) {
                         t.stringContains(stdout,'Debug/'+app.name+'.node');
                     } else {


### PR DESCRIPTION
Allow installing a package with many dependent packages using node-pre-gyp binaries off the same local artifactory.

Avoid erasing the subpath in the mirror value.

Corrects #415 .