### PR TITLE
Fixes the double-download-callback issue.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -113,28 +113,38 @@ function place_binary(from,to,opts,callback) {
         // for request compatibility
         req.on('error', function(err) {
             badDownload = true;
-            return callback(err);
+            if (!hasResponse) {
+                hasResponse = true;
+                return callback(err);
+            }
         });
 
         // for needle compatibility
         req.on('err', function(err) {
             badDownload = true;
-            return callback(err);
+            if (!hasResponse) {
+                hasResponse = true;
+                return callback(err);
+            }
         });
 
         req.on('close', function () {
             if (!hasResponse) {
+                hasResponse = true;
                 return callback(new Error('Connection closed while downloading tarball file'));
             }
         });
 
       req.on('response', function(res) {
-           // ignore redirects, needle handles these automatically.
-           if (http_get.type === 'needle' && res.headers.hasOwnProperty('location') && res.headers.location !== '') {
-               return;
-           }
-           hasResponse = true;
-           if (res.statusCode !== 200) {
+            // ignore redirects, needle handles these automatically.
+            if (http_get.type === 'needle' && res.headers.hasOwnProperty('location') && res.headers.location !== '') {
+                return;
+            }
+            if (hasResponse) {
+                return;
+            }
+            hasResponse = true;
+            if (res.statusCode !== 200) {
                 badDownload = true;
                 var err = new Error(res.statusCode + ' status code downloading tarball ' + from);
                 err.statusCode = res.statusCode;


### PR DESCRIPTION
Fixes issue mapbox/node-pre-gyp#426.
The `close` event will also be emitted for error cases. If a download fails, then the callback will be invoked twice with a failure, triggering the fallback-to-source case twice. This will spawn two instances of node-gyp which will most likely corrupt the build.