### PR TITLE
fix: module_name may not be valid variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,10 +707,16 @@ The options are visible in the code at <https://github.com/mapbox/node-pre-gyp/b
 
 S3 is broken in China for the well known reason.
 
-Using the `npm` config argument: `--{module_name}_binary_host_mirror` can download binary files through a mirror.
+Using the `npm` config argument: `--{module_name}_binary_host_mirror` can download binary files through a mirror, `-` in `module_name` will be replaced with `_`.
 
 e.g.: Install [v8-profiler](https://www.npmjs.com/package/v8-profiler) from `npm`.
 
 ```bash
 $ npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
+```
+
+e.g.: Install [canvas-prebuilt](https://www.npmjs.com/package/canvas-prebuilt) from `npm`.
+
+```bash
+$ npm install canvas-prebuilt --canvas_prebuilt_binary_host_mirror=https://npm.taobao.org/mirrors/canvas-prebuilt/
 ```

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -309,7 +309,8 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
     // support host mirror with npm config `--{module_name}_binary_host_mirror`
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://npm.taobao.org/mirrors/node-inspector/
-  const host = process.env['npm_config_' + opts.module_name + '_binary_host_mirror'] || package_json.binary.host;
+  const validModuleName = opts.module_name.replace('-', '_');
+  const host = process.env['npm_config_' + validModuleName + '_binary_host_mirror'] || package_json.binary.host;
   opts.host = fix_slashes(eval_template(host, opts));
   opts.module_path = eval_template(package_json.binary.module_path, opts);
   // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -228,3 +228,24 @@ test('should verify host overrides staging and production values', (t) => {
   t.end();
 });
 
+test('should replace "-" with "_" in custom binary host', (t) => {
+  const mock_package_json = {
+    name: 'test',
+    main: 'test.js',
+    version: '0.1.0',
+    binary: {
+      module_name: 'canvas-prebuilt',
+      module_path: 'build/Release',
+      host: 'https://github.com/node-gfx/node-canvas-prebuilt/releases/download/',
+      remote_path: 'v{version}',
+      package_name: '{module_name}-v{version}-{node_abi}-{platform}-{libc}-{arch}.tar.gz'
+    }
+  };
+
+  process.env.npm_config_canvas_prebuilt_binary_host_mirror = 'https://npm.taobao.org/mirrors/node-canvas-prebuilt/';
+  const opts = versioning.evaluate(mock_package_json, {});
+  t.equal(opts.host, 'https://npm.taobao.org/mirrors/node-canvas-prebuilt/');
+  delete process.env.npm_config_canvas_prebuilt_binary_host_mirror;
+  t.end();
+});
+


### PR DESCRIPTION
For example: 
```
  "binary": {
    "module_name": "canvas-prebuilt",
    "module_path": "build/Release",
    "host": "https://github.com/node-gfx/node-canvas-prebuilt/releases/download/",
    "remote_path": "v{version}",
    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{libc}-{arch}.tar.gz"
  }
```
https://github.com/Automattic/node-canvas/blob/master/package.json#L35