### PR TITLE
[Security] Bump tar from ^4 to ^4.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "rc": "^1.2.7",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
-    "tar": "^4"
+    "tar": "^4.4.2"
   },
   "devDependencies": {
     "aws-sdk": "^2.28.0",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-20834

Sourced from The GitHub Security Advisory Database.

    High severity vulnerability that affects tar
    A vulnerability was found in node-tar before version 4.4.2. An Arbitrary File Overwrite issue exists when extracting a tarball containing a hardlink to a file that already exists on the system, in conjunction with a later plain file with the same name as the hardlink. This plain file content replaces the existing file content.

    Affected versions: < 4.4.2