### PR TITLE
Pin mkdirp version to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "./lib/node-pre-gyp.js",
   "dependencies": {
     "detect-libc": "^1.0.2",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "0.5.1",
     "needle": "^2.2.1",
     "nopt": "^4.0.1",
     "npm-packlist": "^1.1.6",


### PR DESCRIPTION
mkdirp 1.0.0 introduced a massive breaking change, so pin to 0.5.1 until everything is fixed. This would fix errors when installing.