### PR TITLE
Respect npm config runtime, platform, arch

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -279,7 +279,7 @@ module.exports.evaluate = function(package_json,options,napi_build_version) {
     validate_config(package_json,options); // options is a suitable substitute for opts in this case
     var v = package_json.version;
     var module_version = semver.parse(v);
-    var runtime = options.runtime || get_process_runtime(process.versions);
+    var runtime = options.runtime || process.env.npm_config_runtime || get_process_runtime(process.versions);
     var opts = {
         name: package_json.name,
         configuration: Boolean(options.debug) ? 'Debug' : 'Release',
@@ -297,11 +297,11 @@ module.exports.evaluate = function(package_json,options,napi_build_version) {
         napi_version: napi.get_napi_version(options.target), // non-zero numeric, undefined if unsupported
         napi_build_version: napi_build_version || '',
         node_napi_label: napi_build_version ? 'napi-v' + napi_build_version : get_runtime_abi(runtime,options.target),
-        target: options.target || '',
-        platform: options.target_platform || process.platform,
-        target_platform: options.target_platform || process.platform,
-        arch: options.target_arch || process.arch,
-        target_arch: options.target_arch || process.arch,
+        target: options.target || process.env.npm_config_target || '',
+        platform: options.target_platform || process.env.npm_config_platform || process.platform,
+        target_platform: options.target_platform || process.env.npm_config_platform || process.platform,
+        arch: options.target_arch || process.env.npm_config_arch || process.arch,
+        target_arch: options.target_arch || process.env.npm_config_arch || process.arch,
         libc: options.target_libc || detect_libc.family || 'unknown',
         module_main: package_json.main,
         toolset : options.toolset || '' // address https://github.com/mapbox/node-pre-gyp/issues/119


### PR DESCRIPTION
We are currently building our Windows platform on Linux. `node-pre-gyp` does not seem to support many ways I could find to influence these settings outside of command options. This PR aims to respect `.npmrc` config much like `prebuild-install` does here:

https://github.com/prebuild/prebuild-install/blob/406b0513833be7c9e909128e642a42e82242f720/rc.js#L35

If there is a way to do this through an environment variable or something else, please advise and I can close this.

The particular aim of these particular options is to support installing a prebuilt electron module for `sqlite3` on a different platform and architecture. 