### PR TITLE
Security vulnerabilities pulled in by packlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^0.5.3",
     "needle": "^2.5.0",
     "nopt": "^4.0.1",
-    "npm-packlist": "^1.1.6",
+    "npm-packlist": "^2",
     "npmlog": "^4.0.2",
     "rc": "^1.2.7",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
npm-packlist versions < 2.0.2 brings in security vulnerabilities and must be updated to version 2 to resolve this issue.

Description of the vulnerability:
Versions of the npm CLI prior to 6.13.3 are vulnerable to an Arbitrary File Write. It is possible for packages to create symlinks to files outside of the node_modules folder through the bin field upon installation. A properly constructed entry in the package.json bin field would allow a package publisher to create a symlink pointing to arbitrary files on a user's system when the package is installed. This behavior is still possible through install scripts. This vulnerability bypasses a user using the --ignore-scripts install option.

References:
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-16776
https://nvd.nist.gov/vuln/detail/CVE-2019-16775


packlist also brings in npm-bundled, which brings in the same security vulnerability. Updating to version 2 solves both problems. The version changes should not affect this module. 
