### PR TITLE
allow prod & stage s3 targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Switched tests to use mapbox-owned bucket
 - Added coverage tracking and linting with eslint
 - Upgraded all test apps to N-API/node-addon-api
+- new: support for staging and production s3 targets (see README.md)
 
 ## 0.17.0
 - Got travis + appveyor green again

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ must be true.
 
 If any of these checks fail then the operation will not perform execution time determination of the s3 target.
 
-If the command being executed is "publish" the the default is set to `binary.staging_host`. In all other cases
+If the command being executed is "publish" then the default is set to `binary.staging_host`. In all other cases
 the default is `binary.production_host`.
 
 The command-line options `--s3_host staging` or `--s3_host production` override the default. If `s3_host`

--- a/README.md
+++ b/README.md
@@ -298,11 +298,11 @@ If any of these checks fail then the operation will not perform execution time d
 If the command being executed is "publish" then the default is set to `binary.staging_host`. In all other cases
 the default is `binary.production_host`.
 
-The command-line options `--s3_host staging` or `--s3_host production` override the default. If `s3_host`
+The command-line options `--s3_host=staging` or `--s3_host=production` override the default. If `s3_host`
 is not `staging` or `production` an exception is thrown.
 
-This allows installing from staging by specifying `--s3_host staging`. And it requires specifying
-`--s3_option production` in order to publish to production making accidental publishing less likely.
+This allows installing from staging by specifying `--s3_host=staging`. And it requires specifying
+`--s3_option=production` in order to publish to production making accidental publishing less likely.
 
 ## N-API Considerations
 

--- a/bin/node-pre-gyp
+++ b/bin/node-pre-gyp
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /**
  * Set the title.

--- a/bin/node-pre-gyp
+++ b/bin/node-pre-gyp
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-'use strict';
-
 /**
  * Set the title.
  */
@@ -26,13 +24,13 @@ prog.parseArgv(process.argv);
 if (prog.todo.length === 0) {
   if (~process.argv.indexOf('-v') || ~process.argv.indexOf('--version')) {
     console.log('v%s', prog.version);
-    return process.exit(0);
+    process.exit(0);
   } else if (~process.argv.indexOf('-h') || ~process.argv.indexOf('--help')) {
     console.log('%s', prog.usage());
-    return process.exit(0);
+    process.exit(0);
   }
   console.log('%s', prog.usage());
-  return process.exit(1);
+  process.exit(1);
 }
 
 // if --no-color is passed
@@ -77,6 +75,12 @@ function run() {
     completed = true;
     log.info('ok');
     return;
+  }
+
+  // set binary.host when appropriate. host determines the s3 target bucket.
+  const target = prog.setBinaryHostProperty(command.name);
+  if (target) {
+    log.info('setting binary.host to ' + prog.package_json.binary.host);
   }
 
   prog.commands[command.name](command.args, function(err) {

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,10 +1,8 @@
-'use strict';
 
 module.exports = exports = clean;
 
 exports.usage = 'Removes the entire folder containing the compiled .node module';
 
-const fs = require('fs');
 const rm = require('rimraf');
 const exists = require('fs').exists || require('path').exists;
 const versioning = require('./util/versioning.js');
@@ -12,7 +10,7 @@ const napi = require('./util/napi.js');
 const path = require('path');
 
 function clean(gyp, argv, callback) {
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   const to_delete = opts.module_path;

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = clean;
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -1,10 +1,8 @@
-'use strict';
 
 module.exports = exports = info;
 
 exports.usage = 'Lists all published binaries (requires aws-sdk)';
 
-const fs = require('fs');
 const log = require('npmlog');
 const versioning = require('./util/versioning.js');
 const s3_setup = require('./util/s3_setup.js');
@@ -12,7 +10,7 @@ const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function info(gyp, argv, callback) {
   const AWS = require('aws-sdk');
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const opts = versioning.evaluate(package_json, gyp.opts);
   s3_setup.detect(opts.hosted_path, config);
   AWS.config.update(config);
@@ -20,7 +18,7 @@ function info(gyp, argv, callback) {
   const s3_opts = {  Bucket: config.bucket,
     Prefix: config.prefix
   };
-  s3.listObjects(s3_opts, (err, meta)=> {
+  s3.listObjects(s3_opts, (err, meta) => {
     if (err && err.code === 'NotFound') {
       return callback(new Error('[' + package_json.name + '] Not found: https://' + s3_opts.Bucket + '.s3.amazonaws.com/' + config.prefix));
     } else if (err) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = info;
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = install;
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = exports = install;
 
@@ -218,7 +217,7 @@ function print_fallback_error(err, opts, package_json) {
 }
 
 function install(gyp, argv, callback) {
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const source_build = gyp.opts['build-from-source'] || gyp.opts.build_from_source;
   const update_binary = gyp.opts['update-binary'] || gyp.opts.update_binary;

--- a/lib/node-pre-gyp.js
+++ b/lib/node-pre-gyp.js
@@ -59,11 +59,7 @@ exports.find = require('./pre-binding').find;
 // that's why "find()" must pass the path to package.json.
 //
 function Run(package_json_path = './package.json') {
-  try {
-    this.package_json = JSON.parse(fs.readFileSync(package_json_path));
-  } catch (e) {
-    log.error(e.code, e.message);
-  }
+  this.package_json = JSON.parse(fs.readFileSync(package_json_path));
 
   this.commands = {};
 
@@ -223,7 +219,7 @@ proto.parseArgv = function parseOpts(argv) {
  */
 proto.setBinaryHostProperty = function(command) {
   if (this.binaryHostSet) {
-    return;
+    return this.package_json.binary.host;
   }
   const p = this.package_json;
   // don't set anything if host is present. it must be left blank to trigger this.

--- a/lib/node-pre-gyp.js
+++ b/lib/node-pre-gyp.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Module exports.
  */
@@ -41,17 +39,42 @@ log.heading = 'node-pre-gyp';
 
 exports.find = require('./pre-binding').find;
 
-function Run() {
-  const self = this;
+//
+// in the following, "my_module" is using node-pre-gyp to
+// prebuild and install pre-built binaries. "main_module"
+// is using "my_module".
+//
+// "bin/node-pre-gyp" invokes Run() without a path. the
+// expectation is that the working directory is the package
+// root "my_module". this is true because in all cases npm is
+// executing a script in the context of "my_module".
+//
+// "pre-binding.find()" is executed by "my_module" but in the
+// context of "main_module". this is because "main_module" is
+// executing and requires "my_module" which is then executing
+// "pre-binding.find()" via "node-pre-gyp.find()", so the working
+// directory is that of "main_module".
+//
+// that's why "find()" must pass the path to package.json.
+//
+function Run(package_json_path = './package.json') {
+  try {
+    this.package_json = JSON.parse(fs.readFileSync(package_json_path));
+  } catch (e) {
+    log.error(e.code, e.message);
+  }
 
   this.commands = {};
 
+  const self = this;
   cli_commands.forEach((command) => {
     self.commands[command] = function(argv, callback) {
       log.verbose('command', command, argv);
       return require('./' + command)(self, argv, callback);
     };
   });
+  // the destination for the binaries has not yet been set.
+  this.binaryHostSet = false;
 }
 inherits(Run, EE);
 exports.Run = Run;
@@ -168,6 +191,64 @@ proto.parseArgv = function parseOpts(argv) {
     log.level = this.opts.loglevel;
   }
   log.resume();
+};
+
+/**
+ * allow the binary.host property to be set at execution time.
+ *
+ * for this to take effect requires all the following to be true.
+ * - binary is a property in package.json
+ * - binary.host is falsey
+ * - binary.staging_host is not empty
+ * - binary.production_host is not empty
+ *
+ * if any of the previous checks fail then the function returns an empty string
+ * and makes no changes to package.json's binary property.
+ *
+ *
+ * if command is "publish" then the default is set to "binary.staging_host"
+ * if command is not "publish" the the default is set to "binary.production_host"
+ *
+ * if the command-line option '--s3_host' is set to "staging" or "production" then
+ * "binary.host" is set to the specified "staging_host" or "production_host". if
+ * '--s3_host' is any other value an exception is thrown.
+ *
+ * if '--s3_host' is not present then "binary.host" is set to the default as above.
+ *
+ * this strategy was chosen so that any command other than "publish" uses "production"
+ * as the default without requiring any command-line options but that "publish" requires
+ * '--s3_host production_host' to be specified in order to *really* publish. publishing
+ * to staging can be done freely without worrying about disturbing any production releases.
+ */
+proto.setBinaryHostProperty = function(command) {
+  if (this.binaryHostSet) {
+    return;
+  }
+  const p = this.package_json;
+  // don't set anything if host is present. it must be left blank to trigger this.
+  if (!p || !p.binary || p.binary.host) {
+    return '';
+  }
+  // and both staging and production must be present. errors will be reported later.
+  if (!p.binary.staging_host || !p.binary.production_host) {
+    return '';
+  }
+  let target = 'production_host';
+  if (command === 'publish') {
+    target = 'staging_host';
+  }
+  if (this.opts['s3_host'] === 'staging') {
+    target = 'staging_host';
+  } else if (this.opts['s3_host'] === 'production') {
+    target = 'production_host';
+  } else if (this.opts['s3_host']) {
+    throw new Error(`invalid s3_host ${this.opts['s3_host']}`);
+  }
+
+  p.binary.host = p.binary[target];
+  this.binaryHostSet = true;
+
+  return p.binary.host;
 };
 
 /**

--- a/lib/node-pre-gyp.js
+++ b/lib/node-pre-gyp.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Module exports.
  */

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = exports = _package;
 
@@ -15,7 +14,7 @@ const tar = require('tar');
 
 function _package(gyp, argv, callback) {
   const packlist = require('npm-packlist');
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   const from = opts.module_path;

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = _package;
 

--- a/lib/pre-binding.js
+++ b/lib/pre-binding.js
@@ -1,5 +1,5 @@
-'use strict';
 
+const npg = require('..');
 const versioning = require('../lib/util/versioning.js');
 const napi = require('../lib/util/napi.js');
 const existsSync = require('fs').existsSync || require('path').existsSync;
@@ -15,9 +15,13 @@ exports.validate = function(package_json, opts) {
 
 exports.find = function(package_json_path, opts) {
   if (!existsSync(package_json_path)) {
-    throw new Error('package.json does not exist at ' + package_json_path);
+    throw new Error(package_json_path + 'does not exist');
   }
-  const package_json = require(package_json_path);
+  const prog = new npg.Run(package_json_path);
+  prog.parseArgv(process.argv);
+  prog.setBinaryHostProperty();
+  const package_json = prog.package_json;
+
   versioning.validate_config(package_json, opts);
   let napi_build_version;
   if (napi.get_napi_build_versions(package_json, opts)) {

--- a/lib/pre-binding.js
+++ b/lib/pre-binding.js
@@ -1,3 +1,4 @@
+'use strict';
 
 const npg = require('..');
 const versioning = require('../lib/util/versioning.js');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = exports = publish;
 
@@ -16,7 +15,7 @@ const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function publish(gyp, argv, callback) {
   const AWS = require('aws-sdk');
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   const tarball = opts.staged_tarball;
@@ -29,13 +28,14 @@ function publish(gyp, argv, callback) {
     const key_name = url.resolve(config.prefix, opts.package_name);
     log.info('publish', 'Authenticating with s3');
     AWS.config.update(config);
+    log.info('publish', AWS.config);
     const s3 =  new AWS.S3();
     const s3_opts = {  Bucket: config.bucket,
       Key: key_name
     };
     const remote_package = 'https://' + s3_opts.Bucket + '.s3.amazonaws.com/' + s3_opts.Key;
     log.info('publish', 'Checking for existing binary at ' + remote_package);
-    s3.headObject(s3_opts, (err, meta)=> {
+    s3.headObject(s3_opts, (err, meta) => {
       if (meta) log.info('publish', JSON.stringify(meta));
       if (err && err.code === 'NotFound') {
         // we are safe to publish because
@@ -47,9 +47,9 @@ function publish(gyp, argv, callback) {
           Bucket: config.bucket,
           Key: key_name
         };
-        log.info('publish', 'Putting object');
+        log.info('publish', 'Putting object', s3_put_opts.ACL, s3_put_opts.Bucket, s3_put_opts.Key);
         try {
-          s3_put.putObject(s3_put_opts, (err2, resp)=> {
+          s3_put.putObject(s3_put_opts, (err2, resp) => {
             log.info('publish', 'returned from putting object');
             if (err2) {
               log.info('publish', 's3 putObject error: "' + err2 + '"');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = publish;
 

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = rebuild;
 

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -1,14 +1,12 @@
-'use strict';
 
 module.exports = exports = rebuild;
 
 exports.usage = 'Runs "clean" and "build" at once';
 
-const fs = require('fs');
 const napi = require('./util/napi.js');
 
 function rebuild(gyp, argv, callback) {
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   let commands = [
     { name: 'clean', args: [] },
     { name: 'build', args: ['rebuild'] }

--- a/lib/reinstall.js
+++ b/lib/reinstall.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = rebuild;
 

--- a/lib/reinstall.js
+++ b/lib/reinstall.js
@@ -1,14 +1,12 @@
-'use strict';
 
 module.exports = exports = rebuild;
 
 exports.usage = 'Runs "clean" and "install" at once';
 
-const fs = require('fs');
 const napi = require('./util/napi.js');
 
 function rebuild(gyp, argv, callback) {
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   let installArgs = [];
   const napi_build_version = napi.get_best_napi_build_version(package_json, gyp.opts);
   if (napi_build_version != null) installArgs = [napi.get_command_arg(napi_build_version)];

--- a/lib/reveal.js
+++ b/lib/reveal.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = reveal;
 

--- a/lib/reveal.js
+++ b/lib/reveal.js
@@ -1,10 +1,8 @@
-'use strict';
 
 module.exports = exports = reveal;
 
 exports.usage = 'Reveals data on the versioned binary';
 
-const fs = require('fs');
 const versioning = require('./util/versioning.js');
 const napi = require('./util/napi.js');
 
@@ -13,7 +11,7 @@ function unix_paths(key, val) {
 }
 
 function reveal(gyp, argv, callback) {
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   let hit = false;

--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = testbinary;
 

--- a/lib/testbinary.js
+++ b/lib/testbinary.js
@@ -1,10 +1,8 @@
-'use strict';
 
 module.exports = exports = testbinary;
 
 exports.usage = 'Tests that the binary.node can be required';
 
-const fs = require('fs');
 const path = require('path');
 const log = require('npmlog');
 const cp = require('child_process');
@@ -15,7 +13,7 @@ function testbinary(gyp, argv, callback) {
   const args = [];
   const options = {};
   let shell_cmd = process.execPath;
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   // skip validation for runtimes we don't explicitly support (like electron)

--- a/lib/testpackage.js
+++ b/lib/testpackage.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = exports = testpackage;
 
@@ -15,7 +14,7 @@ const tar = require('tar');
 const mkdirp = require('mkdirp');
 
 function testpackage(gyp, argv, callback) {
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   const tarball = opts.staged_tarball;

--- a/lib/testpackage.js
+++ b/lib/testpackage.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = testpackage;
 

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = unpublish;
 

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -1,10 +1,8 @@
-'use strict';
 
 module.exports = exports = unpublish;
 
 exports.usage = 'Unpublishes pre-built binary (requires aws-sdk)';
 
-const fs = require('fs');
 const log = require('npmlog');
 const versioning = require('./util/versioning.js');
 const napi = require('./util/napi.js');
@@ -14,7 +12,7 @@ const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function unpublish(gyp, argv, callback) {
   const AWS = require('aws-sdk');
-  const package_json = JSON.parse(fs.readFileSync('./package.json'));
+  const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   s3_setup.detect(opts.hosted_path, config);

--- a/lib/util/handle_gyp_opts.js
+++ b/lib/util/handle_gyp_opts.js
@@ -1,8 +1,6 @@
-'use strict';
 
 module.exports = exports = handle_gyp_opts;
 
-const fs = require('fs');
 const versioning = require('./versioning.js');
 const napi = require('./napi.js');
 
@@ -57,7 +55,7 @@ function handle_gyp_opts(gyp, argv, callback) {
   const node_pre_gyp_options = [];
   // generate custom node-pre-gyp versioning info
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
-  const opts = versioning.evaluate(JSON.parse(fs.readFileSync('./package.json')), gyp.opts, napi_build_version);
+  const opts = versioning.evaluate(gyp.package_json, gyp.opts, napi_build_version);
   share_with_node_gyp.forEach((key) => {
     const val = opts[key];
     if (val) {

--- a/lib/util/handle_gyp_opts.js
+++ b/lib/util/handle_gyp_opts.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports = handle_gyp_opts;
 

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = exports;
 

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = exports;
 
@@ -208,14 +207,14 @@ function validate_config(package_json, opts) {
     missing.push('binary');
   }
   const o = package_json.binary;
-  required_parameters.forEach((p) => {
-    if (missing.indexOf('binary') > -1) {
-      missing.pop('binary');
-    }
-    if (!o || o[p] === undefined || o[p] === '') {
-      missing.push('binary.' + p);
-    }
-  });
+  if (o) {
+    required_parameters.forEach((p) => {
+      if (!o[p] || typeof o[p] !== 'string') {
+        missing.push('binary.' + p);
+      }
+    });
+  }
+
   if (missing.length >= 1) {
     throw new Error(msg + 'package.json must declare these properties: \n' + missing.join('\n'));
   }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,4 +1,4 @@
-'use strict';
+const fs = require('fs');
 
 const test = require('tape');
 const nock = require('nock');
@@ -19,6 +19,8 @@ test('should follow redirects', (t) => {
 
   const opts = {
     opts: {
+      // commands no longer read package.json to it must be passed to them.
+      package_json: JSON.parse(fs.readFileSync('./package.json')),
       'build-from-source': false,
       'update-binary': true
     }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 
 const test = require('tape');

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -19,14 +19,15 @@ test('should follow redirects', (t) => {
 
   const opts = {
     opts: {
-      // commands no longer read package.json to it must be passed to them.
-      package_json: JSON.parse(fs.readFileSync('./package.json')),
       'build-from-source': false,
       'update-binary': true
     }
   };
 
   process.chdir('test/app1');
+
+  // commands no longer read package.json so it must be passed to them.
+  opts.package_json = JSON.parse(fs.readFileSync('./package.json'));
 
   install(opts, [], (err) => {
     t.ifError(err); // Worked fine

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
+const npg = require('../lib/node-pre-gyp.js');
 const versioning = require('../lib/util/versioning.js');
 const test = require('tape');
 const detect_libc = require('detect-libc');
@@ -103,7 +105,7 @@ test('should detect custom binary host from env', (t) => {
       'host': 'https://some-bucket.s3.us-east-1.amazonaws.com'
     }
   };
-    // mock npm_config_test_binary_host_mirror env
+  // mock npm_config_test_binary_host_mirror env
   process.env.npm_config_test_binary_host_mirror = 'https://npm.taobao.org/mirrors/node-inspector/';
   const opts = versioning.evaluate(mock_package_json, {});
   t.equal(opts.host, 'https://npm.taobao.org/mirrors/node-inspector/');
@@ -134,3 +136,231 @@ test('should detect libc', (t) => {
   t.equal(opts.hosted_tarball, 'https://some-bucket.s3-us-west-1.amazonaws.com/test/' + expected_libc_token + '/test-' + expected_libc_token + '.tar.gz');
   t.end();
 });
+
+//
+// validate package.json versioning configurations
+//
+test('should verify that package.json has required properties', (t) => {
+  const mock_package_json = {
+    'name': 'test',
+    'main': 'test.js',
+    'version': '0.1.0',
+    'binary': {
+      'module_name': 'binary-module-name',
+      'module_path': 'binary-module-path',
+      'host': 'binary-path'
+    }
+  };
+  const requireds = Object.keys(mock_package_json);
+
+  for (let i = 0; i < requireds.length; i++) {
+    const package_json = Object.assign({}, mock_package_json);
+    delete package_json[requireds[i]];
+    const missing = [requireds[i]];
+
+    try {
+      // eslint-disable-next-line no-unused-vars
+      const opts = versioning.evaluate(package_json, { module_root: '/root' });
+    } catch (e) {
+      // name won't be there if it's missing but both messages say 'undefined'
+      const msg = package_json.name + ' package.json is not node-pre-gyp ready:\n';
+      const expectedMessage = msg + 'package.json must declare these properties: \n' + missing.join('\n');
+      t.equal(e.message, expectedMessage);
+    }
+  }
+  t.end();
+});
+
+test('should verify that the binary property has required properties', (t) => {
+  const mock_package_json = {
+    'name': 'test',
+    'main': 'test.js',
+    'version': '0.1.0',
+    'binary': {
+      'module_name': 'binary-module-name',
+      'module_path': 'binary-module-path',
+      'host': 'binary-path'
+    }
+  };
+  const requireds = Object.keys(mock_package_json.binary);
+
+  for (let i = 0; i < requireds.length; i++) {
+    const package_json = Object.assign({}, mock_package_json);
+    package_json.binary = Object.assign({}, mock_package_json.binary);
+
+    delete package_json.binary[requireds[i]];
+    const missing = ['binary.' + requireds[i]];
+
+    try {
+      // eslint-disable-next-line no-unused-vars
+      const opts = versioning.evaluate(package_json, { module_root: '/root' });
+    } catch (e) {
+      // name won't be there if it's missing but both messages say 'undefined'
+      const msg = package_json.name + ' package.json is not node-pre-gyp ready:\n';
+      const expectedMessage = msg + 'package.json must declare these properties: \n' + missing.join('\n');
+      t.equal(e.message, expectedMessage);
+    }
+  }
+  t.end();
+});
+
+test('should verify host overrides staging and production values', (t) => {
+  const mock_package_json = {
+    name: 'test',
+    main: 'test.js',
+    version: '0.1.0',
+    binary: {
+      module_name: 'binary-module-name',
+      module_path: 'binary-module-path',
+      host: '',
+      staging_host: 's3-staging-path',
+      production_host: 's3-production-path'
+    }
+  };
+
+  try {
+    // eslint-disable-next-line no-unused-vars
+    const opts = versioning.evaluate(mock_package_json, { module_root: '/root' });
+    t.equal(opts.host, mock_package_json.binary.host + '/');
+    t.equal(opts.hosted_path, mock_package_json.binary.host + '/');
+    t.equal(opts.hosted_tarball, mock_package_json.binary.host + '/' + opts.package_name);
+  } catch (e) {
+    t.ifError(e, 'staging_host and production_host should be silently ignored');
+  }
+
+  t.end();
+  return;
+
+});
+
+test.only('should set staging and production hosts', (t) => {
+  // make sure it's good when specifying host.
+  const mock_package_json = {
+    'name': 'test',
+    'main': 'test.js',
+    'version': '0.1.0',
+    'binary': {
+      'module_name': 'binary-module-name',
+      'module_path': 'binary-module-path',
+      'host': 'resolved-s3-path',
+      'staging_host': 's3-staging-path',
+      'production_host': 's3-production-path'
+    }
+  };
+
+  const dir = './.tmp';
+
+  let { prog } = setupTest(dir, mock_package_json);
+  t.deepEqual(prog.package_json, mock_package_json);
+  t.equal(prog.binaryHostSet, false, 'binary host should not be flagged as set');
+
+  const all_commands = ['build', 'clean', 'configure', 'info', 'install', 'package', 'publish', 'rebuild',
+    'reinstall', 'reveal', 'testbinary', 'testpackage', 'unpublish'];
+
+  // test with no s3_host option
+  all_commands.forEach((cmd) => {
+    const mpj = clone(mock_package_json);
+    mpj.binary.host = '';
+    const opts = { argv: [cmd] };
+    ({ prog } = setupTest(dir, mpj, opts));
+    mpj.binary.host = cmd === 'publish' ? mpj.binary.staging_host : mpj.binary.production_host;
+    t.deepEqual(prog.package_json, mpj, 'host should be correct for command: ' + cmd);
+    t.equal(prog.binaryHostSet, true, 'binary host should be flagged as set');
+  });
+
+  // test with s3_host set to staging
+  all_commands.forEach((cmd) => {
+    const mpj = clone(mock_package_json);
+    mpj.binary.host = '';
+    const opts = { argv: [cmd, '--s3_host=staging'] };
+    ({ prog } = setupTest(dir, mpj, opts));
+    mpj.binary.host = mpj.binary.staging_host;
+    t.deepEqual(prog.package_json, mpj, 'host should be correct for command: ' + cmd);
+    t.equal(prog.binaryHostSet, true, 'binary host should be flagged as set');
+  });
+
+  // test with s3_host set to production
+  all_commands.forEach((cmd) => {
+    const mpj = clone(mock_package_json);
+    mpj.binary.host = '';
+    const opts = { argv: [cmd, '--s3_host=production'] };
+    ({ prog } = setupTest(dir, mpj, opts));
+    mpj.binary.host = mpj.binary.production_host;
+    t.deepEqual(prog.package_json, mpj, 'host should be correct for command: ' + cmd);
+    t.equal(prog.binaryHostSet, true, 'binary host should be flagged as set');
+  });
+
+  test.onFinish(() => {
+    fs.unlinkSync('.tmp/package.json');
+    fs.rmdirSync('.tmp');
+  });
+
+  t.end();
+});
+
+test.onFinish(() => {
+
+});
+
+//
+// test helpers.
+//
+
+// helper to write package.json to disk so Run() can be instantiated with it.
+function setupTest(dir, package_json, opts) {
+  opts = opts || {};
+  let argv = ['node', 'program'];
+  if (opts.argv) {
+    argv = argv.concat(opts.argv);
+  }
+  const prev_dir = process.cwd();
+  try {
+    fs.mkdirSync(dir);
+  } catch (e) {
+    if (e.code !== 'EEXIST') {
+      throw e;
+    }
+  }
+  process.chdir(dir);
+
+  try {
+    fs.writeFileSync('package.json', JSON.stringify(package_json));
+
+    const prog = new npg.Run('./package.json');
+    prog.parseArgv(argv);
+    prog.setBinaryHostProperty(prog.todo[0] && prog.todo[0].name);
+    return { prog };
+  } catch (e) { // eslint-disable-line no-useless-catch
+    throw e;
+  }
+  finally {
+    process.chdir(prev_dir);
+  }
+}
+
+// helper to clone mock package.json. it's overkill for existing tests
+// but is future-proof.
+// https://stackoverflow.com/questions/4459928/how-to-deep-clone-in-javascript
+function clone(obj, hash = new WeakMap()) {
+  if (Object(obj) !== obj) return obj;      // primitives
+  if (hash.has(obj)) return hash.get(obj);  // cyclic reference
+  let result;
+
+  if (obj instanceof Set) {
+    result = new Set(obj);                  // treat set as a value
+  } else if (obj instanceof Map) {
+    result = new Map(Array.from(obj, ([key, val]) => [key, clone(val, hash)]));
+  } else if (obj instanceof Date) {
+    result = new Date(obj);
+  } else if (obj instanceof RegExp) {
+    result = new RegExp(obj.source, obj.flags);
+  } else if (obj.constructor) {
+    result = new obj.constructor();
+  } else {
+    result = Object.create(null);
+  }
+  hash.set(obj, result);
+  return Object.assign(result, ...Object.keys(obj).map((key) => {
+    return { [key]: clone(obj[key], hash) };
+  }));
+}

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -212,7 +212,7 @@ test('should verify host overrides staging and production values', (t) => {
     binary: {
       module_name: 'binary-module-name',
       module_path: 'binary-module-path',
-      host: '',
+      host: 'binary-path',
       staging_host: 's3-staging-path',
       production_host: 's3-production-path'
     }
@@ -233,7 +233,7 @@ test('should verify host overrides staging and production values', (t) => {
 
 });
 
-test.only('should set staging and production hosts', (t) => {
+test('should set staging and production hosts', (t) => {
   // make sure it's good when specifying host.
   const mock_package_json = {
     'name': 'test',
@@ -325,15 +325,11 @@ function setupTest(dir, package_json, opts) {
 
   try {
     fs.writeFileSync('package.json', JSON.stringify(package_json));
-
     const prog = new npg.Run('./package.json');
     prog.parseArgv(argv);
     prog.setBinaryHostProperty(prog.todo[0] && prog.todo[0].name);
     return { prog };
-  } catch (e) { // eslint-disable-line no-useless-catch
-    throw e;
-  }
-  finally {
+  } finally {
     process.chdir(prev_dir);
   }
 }


### PR DESCRIPTION
## allow the binary.host property (the s3 target) to be set at execution time.

for this to take effect requires all the following to be true.
- binary.host is falsey
- binary.staging_host is not empty
- binary.production_host is not empty

if any of the previous are not true then binary.host is used, as it is now.

the command line option, `--s3_host` can specify `staging` or `production`, e.g.,
`--s3_host=staging`. if the value is not `staging` or `production` and exception is
thrown. 

defaults when `--s3_host` is not specified:
 - if command is "publish" then the default is set to "binary.staging_host"
 - if command is not "publish" the the default is set to "binary.production_host"
 
these defaults were chosen so that any command other than "publish" uses "production"
as the default without requiring any command-line options while "publish" requires
'--s3_host production_host' to be specified in order to *really* publish. publishing
to staging can be done freely without worrying about disturbing any production releases.

the main change this required is to centralize the reading (and preprocessing) or package.json. there is a duplicate of
the minor fix in the linux-differentiation PR to verify required binary properties.
