### PR TITLE
change tests to use mock s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 .nyc_output
 coverage
 test/*/package-lock.json
+test/app7/build-tmp-napi-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       node_js: 10
       before_install:
         - npm install request
+        - npm install --package-lock-only
       script:
         - npm run lint
         - npm run coverage

--- a/lib/info.js
+++ b/lib/info.js
@@ -10,13 +10,13 @@ const s3_setup = require('./util/s3_setup.js');
 const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function info(gyp, argv, callback) {
-  const AWS = require('aws-sdk');
   const package_json = gyp.package_json;
   const opts = versioning.evaluate(package_json, gyp.opts);
+
   s3_setup.detect(opts.hosted_path, config);
-  AWS.config.update(config);
-  const s3 =  new AWS.S3();
-  const s3_opts = {  Bucket: config.bucket,
+  const s3 = s3_setup.get_s3(config);
+  const s3_opts = {
+    Bucket: config.bucket,
     Prefix: config.prefix
   };
   s3.listObjects(s3_opts, (err, meta) => {

--- a/lib/install.js
+++ b/lib/install.js
@@ -248,6 +248,8 @@ function install(gyp, argv, callback) {
     opts.ca = gyp.opts.ca;
     opts.cafile = gyp.opts.cafile;
 
+    // example
+    // "https://mapbox-node-pre-gyp-public-testing-bucket.s3.us-east-1.amazonaws.com/node-pre-gyp/node-pre-gyp-test-app1/v0.1.0/Release/node-v72-linux-x64.tar.gz"
     const from = opts.hosted_tarball;
     const to = opts.module_path;
     const binary_module = path.join(to, opts.module_name + '.node');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -15,7 +15,6 @@ const url = require('url');
 const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function publish(gyp, argv, callback) {
-  const AWS = require('aws-sdk');
   const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
@@ -24,16 +23,19 @@ function publish(gyp, argv, callback) {
     if (!found) {
       return callback(new Error('Cannot publish because ' + tarball + ' missing: run `node-pre-gyp package` first'));
     }
+
     log.info('publish', 'Detecting s3 credentials');
     s3_setup.detect(opts.hosted_path, config);
+
+    const s3 = s3_setup.get_s3(config);
+    const s3_opts = {
+      Bucket: config.bucket,
+      Prefix: config.prefix
+    };
     const key_name = url.resolve(config.prefix, opts.package_name);
     log.info('publish', 'Authenticating with s3');
-    AWS.config.update(config);
-    log.info('publish', AWS.config);
-    const s3 =  new AWS.S3();
-    const s3_opts = {  Bucket: config.bucket,
-      Key: key_name
-    };
+    log.info('publish', config);
+
     const remote_package = 'https://' + s3_opts.Bucket + '.s3.amazonaws.com/' + s3_opts.Key;
     log.info('publish', 'Checking for existing binary at ' + remote_package);
     s3.headObject(s3_opts, (err, meta) => {
@@ -42,15 +44,17 @@ function publish(gyp, argv, callback) {
         // we are safe to publish because
         // the object does not already exist
         log.info('publish', 'Preparing to put object');
-        const s3_put = new AWS.S3();
-        const s3_put_opts = {  ACL: config.acl,
+
+        // const s3_put = new AWS.S3();
+        const s3_put_opts = {
+          ACL: config.acl,
           Body: fs.createReadStream(tarball),
           Bucket: config.bucket,
           Key: key_name
         };
         log.info('publish', 'Putting object', s3_put_opts.ACL, s3_put_opts.Bucket, s3_put_opts.Key);
         try {
-          s3_put.putObject(s3_put_opts, (err2, resp) => {
+          s3.putObject(s3_put_opts, (err2, resp) => {
             log.info('publish', 'returned from putting object');
             if (err2) {
               log.info('publish', 's3 putObject error: "' + err2 + '"');

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -12,15 +12,15 @@ const url = require('url');
 const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function unpublish(gyp, argv, callback) {
-  const AWS = require('aws-sdk');
   const package_json = gyp.package_json;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
+
   s3_setup.detect(opts.hosted_path, config);
-  AWS.config.update(config);
+  const s3 = s3_setup.get_s3(config);
   const key_name = url.resolve(config.prefix, opts.package_name);
-  const s3 =  new AWS.S3();
-  const s3_opts = {  Bucket: config.bucket,
+  const s3_opts = {
+    Bucket: config.bucket,
     Key: key_name
   };
   s3.headObject(s3_opts, (err, meta) => {

--- a/lib/util/s3_setup.js
+++ b/lib/util/s3_setup.js
@@ -24,3 +24,63 @@ module.exports.detect = function(to, config) {
     }
   }
 };
+
+module.exports.get_s3 = function(config) {
+
+  // if not mocking then setup real s3.
+  if (!process.env.node_pre_gyp_mock_s3) {
+    const AWS = require('aws-sdk');
+
+    AWS.config.update(config);
+    const s3 = new AWS.S3();
+
+    // need to change if additional options need to be specified.
+    return {
+      listObjects(params, callback) {
+        return s3.listObjects(params, callback);
+      },
+      headObject(params, callback) {
+        return s3.headObject(params, callback);
+      },
+      deleteObject(params, callback) {
+        return s3.deleteObject(params, callback);
+      },
+      putObject(params, callback) {
+        return s3.putObject(params, callback);
+      }
+    };
+  }
+
+  // here we're mocking. node_pre_gyp_mock_s3 is the scratch directory
+  // for the mock code.
+  const AWSMock = require('mock-aws-s3');
+
+  AWSMock.config.basePath = process.env.node_pre_gyp_mock_s3;
+
+  const s3 = AWSMock.S3();
+
+  // wrapped callback maker. fs calls return code of ENOENT but AWS.S3 returns
+  // NotFound.
+  const wcb = (fn) => (err, ...args) => {
+    if (err && err.code === 'ENOENT') {
+      err.code = 'NotFound';
+    }
+    return fn(err, ...args);
+  };
+
+  return {
+    listObjects(params, callback) {
+      return s3.listObjects(params, wcb(callback));
+    },
+    headObject(params, callback) {
+      return s3.headObject(params, wcb(callback));
+    },
+    deleteObject(params, callback) {
+      return s3.deleteObject(params, wcb(callback));
+    },
+    putObject(params, callback) {
+      return s3.putObject(params, wcb(callback));
+    }
+  };
+
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-pre-gyp",
-  "version": "0.17.0",
+  "name": "@mapbox/node-pre-gyp",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -509,6 +509,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "brace-expansion": {
@@ -1241,6 +1247,17 @@
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1789,6 +1806,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1888,6 +1914,17 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "mock-aws-s3": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mock-aws-s3/-/mock-aws-s3-4.0.1.tgz",
+      "integrity": "sha512-KJp1zgNjogMXdFBghg2CJF+25zCmnsPXnFJE9ejkPxDLYTy2F5oY3iD1a3r4llgxpkh+EpxUe+HdTemPExqN9Q==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.1",
+        "fs-extra": "^7.0.1",
+        "underscore": "1.8.3"
       }
     },
     "ms": {
@@ -2775,6 +2812,18 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "codecov": "^3.8.1",
     "eslint": "^7.16.0",
     "eslint-plugin-node": "^11.1.0",
+    "mock-aws-s3": "^4.0.1",
     "nock": "^12.0.3",
     "node-addon-api": "^3.1.0",
     "nyc": "^15.1.0",
@@ -56,6 +57,7 @@
     "lint": "eslint bin/node-pre-gyp lib/*js lib/util/*js test/*js scripts/*js",
     "fix": "npm run lint -- --fix",
     "update-crosswalk": "node scripts/abi_crosswalk.js",
-    "test": "tape test/*test.js"
+    "test": "tape test/*test.js",
+    "mock-s3-test": "node_pre_gyp_mock_s3=/tmp/mock/ tape test/*test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lint": "eslint bin/node-pre-gyp lib/*js lib/util/*js test/*js scripts/*js",
     "fix": "npm run lint -- --fix",
     "update-crosswalk": "node scripts/abi_crosswalk.js",
-    "test": "tape test/*test.js",
-    "mock-s3-test": "node_pre_gyp_mock_s3=/tmp/mock/ tape test/*test.js"
+    "no-mock-test": "tape test/*test.js",
+    "test": "node_pre_gyp_mock_s3=$(node -p 'os.tmpdir()')/mock/ tape test/*test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "fix": "npm run lint -- --fix",
     "update-crosswalk": "node scripts/abi_crosswalk.js",
     "no-mock-test": "tape test/*test.js",
-    "test": "node_pre_gyp_mock_s3=$(node -p 'os.tmpdir()')/mock/ tape test/*test.js"
+    "test": "node test/tape-helper.js tape test/*test.js"
   }
 }

--- a/scripts/clear_bucket.js
+++ b/scripts/clear_bucket.js
@@ -5,31 +5,36 @@ const versioning = require('../lib/util/versioning.js');
 const s3_setup = require('../lib/util/s3_setup.js');
 const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
-if (!config.accessKeyId  || !config.secretAccessKey) {
+if ((!config.accessKeyId  || !config.secretAccessKey) && !process.env.node_pre_gyp_mock_s3) {
   throw new Error('Unknown S3 `accessKeyId` and `secretAccessKey`');
 } else {
-  const AWS = require('aws-sdk');
   const package_json = JSON.parse(fs.readFileSync('./test/app1/package.json'));
   const opts = versioning.evaluate(package_json, {});
   s3_setup.detect(opts.hosted_path, config);
-  AWS.config.update(config);
-  const s3 =  new AWS.S3();
-  const s3_opts = {  Bucket: config.bucket,
+  const s3 = s3_setup.get_s3(config);
+  const s3_opts = {
+    Bucket: config.bucket,
     Prefix: config.prefix
   };
   s3.listObjects(s3_opts, (err, meta)=> {
     if (err) {
       throw new Error('[' + package_json.name + '] Not found: https://' + s3_opts.Bucket + '.s3.amazonaws.com/' + config.prefix);
-    } else {
-      meta.Contents.forEach((item) => {
-        const s3_obj_opts = {  Bucket: config.bucket,
-          Key: item.Key
-        };
-        s3.deleteObject(s3_obj_opts, (err2) => {
-          if (err2) console.log(err2);
-          console.log('deleted ' + item.Key);
-        });
-      });
     }
+
+    if (meta.Contents.length === 0) {
+      console.log(`${s3_opts.Bucket}/${s3_opts.Prefix} contains no items`);
+      process.exit(0);
+    }
+
+    meta.Contents.forEach((item) => {
+      const s3_obj_opts = {
+        Bucket: config.bucket,
+        Key: item.Key
+      };
+      s3.deleteObject(s3_obj_opts, (err2) => {
+        if (err2) console.log(err2);
+        console.log('deleted ' + item.Key);
+      });
+    });
   });
 }

--- a/test/app1/package.json
+++ b/test/app1/package.json
@@ -17,7 +17,7 @@
         "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
     },
     "scripts": {
-        "install": "node-pre-gyp install --fallback-to-build",
+        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",
         "test": "node index.js"
     }
 }

--- a/test/app2/package.json
+++ b/test/app2/package.json
@@ -17,7 +17,7 @@
         "host": "https://mapbox-node-pre-gyp-public-testing-bucket.s3.us-east-1.amazonaws.com"
     },
     "scripts": {
-        "install": "node-pre-gyp install --fallback-to-build",
+        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",
         "test": "node index.js"
     }
 }

--- a/test/app3/package.json
+++ b/test/app3/package.json
@@ -17,7 +17,7 @@
         "host": "https://mapbox-node-pre-gyp-public-testing-bucket.s3.us-east-1.amazonaws.com"
     },
     "scripts": {
-        "install": "node-pre-gyp install --fallback-to-build",
+        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",
         "test": "node index.js"
     }
 }

--- a/test/app4/package.json
+++ b/test/app4/package.json
@@ -17,7 +17,7 @@
         "host": "https://mapbox-node-pre-gyp-public-testing-bucket.s3.us-east-1.amazonaws.com"
     },
     "scripts": {
-        "install": "node-pre-gyp install --fallback-to-build",
+        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",
         "test": "node index.js"
     }
 }

--- a/test/app7/package.json
+++ b/test/app7/package.json
@@ -21,6 +21,6 @@
         ]
     },
     "scripts": {
-        "install": "node-pre-gyp install --fallback-to-build"
+        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",
     }
 }

--- a/test/app7/package.json
+++ b/test/app7/package.json
@@ -21,6 +21,6 @@
         ]
     },
     "scripts": {
-        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",
+        "install": "${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build"
     }
 }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -309,7 +309,7 @@ apps.forEach((app) => {
       const opts = {
         cwd: path.join(__dirname, app.name),
         npg_mock_s3: process.env.node_pre_gyp_mock_s3,
-        npg_debug: true
+        npg_debug: false
       };
       run('npm', 'install', '--fallback-to-build=false', app, opts, (err, stdout) => {
         t.ifError(err);

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -271,7 +271,8 @@ apps.forEach((app) => {
     });
   });
 
-  if (process.env.AWS_ACCESS_KEY_ID || process.env.node_pre_gyp_accessKeyId) {
+  const env = process.env;
+  if (env.AWS_ACCESS_KEY_ID || env.node_pre_gyp_accessKeyId || env.node_pre_gyp_mock_s3) {
 
     test(app.name + ' publishes ' + app.args, (t) => {
       run('node-pre-gyp', 'unpublish publish', '', app, {}, (err, stdout) => {
@@ -305,7 +306,12 @@ apps.forEach((app) => {
     });
 
     test(app.name + ' can be installed via remote ' + app.args, (t) => {
-      run('npm', 'install', '--fallback-to-build=false', app, { cwd: path.join(__dirname, app.name) }, (err, stdout) => {
+      const opts = {
+        cwd: path.join(__dirname, app.name),
+        npg_mock_s3: process.env.node_pre_gyp_mock_s3,
+        npg_debug: true
+      };
+      run('npm', 'install', '--fallback-to-build=false', app, opts, (err, stdout) => {
         t.ifError(err);
         t.notEqual(stdout, '');
         t.end();
@@ -313,7 +319,12 @@ apps.forEach((app) => {
     });
 
     test(app.name + ' can be reinstalled via remote ' + app.args, (t) => {
-      run('npm', 'install', '--update-binary --fallback-to-build=false', app, { cwd: path.join(__dirname, app.name) }, (err, stdout) => {
+      const opts = {
+        cwd: path.join(__dirname, app.name),
+        npg_mock_s3: process.env.node_pre_gyp_mock_s3,
+        npg_debug: false
+      };
+      run('npm', 'install', '--update-binary --fallback-to-build=false', app, opts, (err, stdout) => {
         t.ifError(err);
         t.notEqual(stdout, '');
         t.end();
@@ -321,7 +332,12 @@ apps.forEach((app) => {
     });
 
     test(app.name + ' via remote passes tests ' + app.args, (t) => {
-      run('npm', 'install', '', app, { cwd: path.join(__dirname, app.name) }, (err, stdout) => {
+      const opts = {
+        cwd: path.join(__dirname, app.name),
+        npg_mock_s3: process.env.node_pre_gyp_mock_s3,
+        npg_debug: false
+      };
+      run('npm', 'install', '', app, opts, (err, stdout) => {
         t.ifError(err);
         t.notEqual(stdout, '');
         t.end();

--- a/test/create-mock-s3.js
+++ b/test/create-mock-s3.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const nock = require('nock');
+const fs = require('fs');
+const path = require('path');
+
+// the bucket as addressed by http.
+const host = 'https://mapbox-node-pre-gyp-public-testing-bucket.s3.us-east-1.amazonaws.com';
+
+if (!process.env.node_pre_gyp_mock_s3) {
+  throw new Error('missing env var node_pre_gyp_mock_s3');
+}
+
+const mockDir = process.env.node_pre_gyp_mock_s3 + '/mapbox-node-pre-gyp-public-testing-bucket';
+
+// example request:
+// "https://mapbox-node-pre-gyp-public-testing-bucket.s3.us-east-1.amazonaws.com/node-pre-gyp/node-pre-gyp-test-app1/v0.1.0/Release/node-v72-linux-x64.tar.gz"
+// uri:
+// /node-pre-gyp/node-pre-gyp-test-app1/v0.1.0/Release/node-v72-linux-x64.tar.gz
+
+// eslint-disable-next-line no-unused-vars
+function get(uri, requestBody) {
+  const filepath = path.join(mockDir, uri);
+
+  try {
+    fs.accessSync(filepath, fs.constants.R_OK);
+  } catch (e) {
+    return [404, 'not found\n'];
+  }
+
+  // the mock s3 functions just write to disk, so just read from it.
+  return [200, fs.createReadStream(filepath)];
+}
+
+
+// eslint-disable-next-line no-unused-vars
+const scope = nock(host)
+  .persist()
+  .get(() => true)         // accept any uri
+  .reply(get);

--- a/test/create-mock-s3.js
+++ b/test/create-mock-s3.js
@@ -20,12 +20,12 @@ const mockDir = process.env.node_pre_gyp_mock_s3 + '/mapbox-node-pre-gyp-public-
 
 // eslint-disable-next-line no-unused-vars
 function get(uri, requestBody) {
-  const filepath = path.join(mockDir, uri);
+  const filepath = path.join(mockDir, uri.replace('%2B', '+'));
 
   try {
     fs.accessSync(filepath, fs.constants.R_OK);
   } catch (e) {
-    return [404, 'not found\n'];
+    return [404, `not found: ${uri}\n`];
   }
 
   // the mock s3 functions just write to disk, so just read from it.

--- a/test/tape-helper.js
+++ b/test/tape-helper.js
@@ -16,10 +16,7 @@ argv[0] = `${process.cwd()}/node_modules/.bin/tape`;
 const nodePath = node.slice(0, -'/node'.length);
 
 const PATH = `${process.env.PATH}${path.delimiter}${nodePath}`;
-const env = {
-  PATH,
-  node_pre_gyp_mock_s3: `${os.tmpdir()}/mock`
-};
+const env = Object.assign({}, process.env, { PATH, node_pre_gyp_mock_s3: `${os.tmpdir()}/mock` });
 
 const opts = {
   env,

--- a/test/tape-helper.js
+++ b/test/tape-helper.js
@@ -11,9 +11,13 @@ if (argv[0] !== 'tape') {
   throw new Error(`${script} can only help tape, not ${argv[0]}`);
 }
 
+let shell;
 let ext = '';
+let command = node;
 if (os.platform() === 'win32') {
   ext = '.cmd';
+  command = argv.shift();
+  shell = 'cmd.exe';
 }
 
 argv[0] = `${process.cwd()}/node_modules/.bin/tape${ext}`;
@@ -25,10 +29,11 @@ const env = Object.assign({}, process.env, { PATH, node_pre_gyp_mock_s3: `${os.t
 
 const opts = {
   env,
-  stdio: 'inherit'
+  stdio: 'inherit',
+  shell
 };
 
-const child = spawn(node, argv, opts);
+const child = spawn(command, argv, opts);
 
 child.on('close', (code) => {
   process.exit(code);

--- a/test/tape-helper.js
+++ b/test/tape-helper.js
@@ -10,17 +10,15 @@ const [node, script, ...argv] = process.argv.slice();
 if (argv[0] !== 'tape') {
   throw new Error(`${script} can only help tape, not ${argv[0]}`);
 }
+argv[0] = `${process.cwd()}/node_modules/.bin/tape`;
 
 let shell;
-let ext = '';
 let command = node;
 if (os.platform() === 'win32') {
-  ext = '.cmd';
-  command = argv.shift();
+  argv[0] += '.cmd';
   shell = 'cmd.exe';
+  command = argv.shift();
 }
-
-argv[0] = `${process.cwd()}/node_modules/.bin/tape${ext}`;
 
 const nodePath = node.slice(0, -'/node'.length);
 
@@ -32,6 +30,8 @@ const opts = {
   stdio: 'inherit',
   shell
 };
+
+console.log('spawning', command, argv, shell);
 
 const child = spawn(command, argv, opts);
 

--- a/test/tape-helper.js
+++ b/test/tape-helper.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+const [node, script, ...argv] = process.argv.slice();
+
+if (argv[0] !== 'tape') {
+  throw new Error(`${script} can only help tape, not ${argv[0]}`);
+}
+
+argv[0] = `${process.cwd()}/node_modules/.bin/tape`;
+
+const nodePath = node.slice(0, -'/node'.length);
+
+const PATH = `${process.env.PATH}${path.delimiter}${nodePath}`;
+const env = {
+  PATH,
+  node_pre_gyp_mock_s3: `${os.tmpdir()}/mock`
+};
+
+const opts = {
+  env,
+  stdio: 'inherit'
+};
+
+const child = spawn(node, argv, opts);
+
+child.on('close', (code) => {
+  process.exit(code);
+});

--- a/test/tape-helper.js
+++ b/test/tape-helper.js
@@ -11,7 +11,12 @@ if (argv[0] !== 'tape') {
   throw new Error(`${script} can only help tape, not ${argv[0]}`);
 }
 
-argv[0] = `${process.cwd()}/node_modules/.bin/tape`;
+let ext = '';
+if (os.platform() === 'win32') {
+  ext = '.cmd';
+}
+
+argv[0] = `${process.cwd()}/node_modules/.bin/tape${ext}`;
 
 const nodePath = node.slice(0, -'/node'.length);
 


### PR DESCRIPTION
if the env var `node_pre_gyp_mock_s3` is not empty then it is used as the root directory for the mocked s3. e.g., if set to `/tmp/mock` then the `mapbox-node-pre-gyp-public-testing-bucket` will be directory `/tmp/mock/mapbox-node-pre-gyp-public-testing-bucket` and each key will be written to that bucket.

It is now necessary to call `s3_setup.get_s3()` instead of directly instantiating `new AWS.S3()`. only `s3_setup.js` requires `aws-sdk` now because `s3_setup.get_s3()` uses `process.env.node_pre_gyp_mock_s3` to choose between the real S3 and the mock s3.

because the install command uses https rather than s3 to fetch binaries, http must be mocked in testing for that command. i didn't want to embed a decision about mocking http in `lib/install.js` so it got a bit more complicated.

1. there is a new module `test/create-mock-s3.js` that instantiates `nock` and reads from the `node_pre_gyp_mock_s3` directory.
2. all test apps "install" scripts are now: `"${node_pre_gyp_command:-npx node-pre-gyp} install --fallback-to-build",`
3. `test/run.util.js` was modified so that if mocking s3:
    - if the command is `node-pre-gyp`, then it is prefixed with `node -r create-mock-s3.js`
    - if the command is `npm`, then `node_pre_gyp_command` is defined as `node -r create-mock-s3.js node-pre-gyp` and inserted into the exec'd jobs environment. it becomes the command that `npm install` executes (because of 2).

Miscellaneous changes/notes
- add `--npm install --package-lock-only` after installing request
- ignore app7 build artifacts
- it doesn't appear that the `--fallback-to-build=false` arguments in `build.test.js` have an effect in the exec'd tasks.
- `run.util.js` accepts a debugging option

i can't test against mapbox buckets, so it's probably worth a double-check with `npm run no-mock-test`.