### PR TITLE
only mock s3 on builds that post coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,17 @@ services:
 # have more than one run with the same node version
 # otherwise they will clobber each other
 #####
-env:
-  node_pre_gyp_mock_s3=true
 
 matrix:
   include:
     # Test node v10 with request override + coverage reporting
     - os: linux
       node_js: 10
+      # mock s3 on jobs that post coverage
+      # to allow coverage to work consistently
+      # across PRs from external contributors
+      env:
+        - node_pre_gyp_mock_s3=true
       before_install:
         - npm install request
         - npm install --package-lock-only
@@ -28,6 +31,11 @@ matrix:
     # Test node v12 with needle + coverage reporting
     - os: linux
       node_js: 12
+      # mock s3 on jobs that post coverage
+      # to allow coverage to work consistently
+      # across PRs from external contributors
+      env:
+        - node_pre_gyp_mock_s3=true
       script:
         - npm run coverage
       after_script:


### PR DESCRIPTION
Hoping that this PR will catch the bug mentioned in https://github.com/mapbox/node-pre-gyp/pull/543 (for the non-coverage builds)