### PR TITLE
add node_pre_gyp_s3_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added coverage tracking and linting with eslint
 - Upgraded all test apps to N-API/node-addon-api
 - new: support for staging and production s3 targets (see README.md)
+- added `node_pre_gyp_s3_host` env var which has priority over the `--s3_host` option or default.
 
 ## 0.17.0
 - Got travis + appveyor green again

--- a/README.md
+++ b/README.md
@@ -299,10 +299,12 @@ If the command being executed is "publish" then the default is set to `binary.st
 the default is `binary.production_host`.
 
 The command-line options `--s3_host=staging` or `--s3_host=production` override the default. If `s3_host`
-is not `staging` or `production` an exception is thrown.
+is present and not `staging` or `production` an exception is thrown.
 
 This allows installing from staging by specifying `--s3_host=staging`. And it requires specifying
 `--s3_option=production` in order to publish to production making accidental publishing less likely.
+
+The environment variable `node_pre_gyp_s3_host` overrides both the `--s3_host` option and the default.
 
 ## N-API Considerations
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -7,10 +7,10 @@ exports.usage = 'Lists all published binaries (requires aws-sdk)';
 const log = require('npmlog');
 const versioning = require('./util/versioning.js');
 const s3_setup = require('./util/s3_setup.js');
-const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function info(gyp, argv, callback) {
   const package_json = gyp.package_json;
+  const config = gyp.rc;
   const opts = versioning.evaluate(package_json, gyp.opts);
 
   s3_setup.detect(opts.hosted_path, config);

--- a/lib/node-pre-gyp.js
+++ b/lib/node-pre-gyp.js
@@ -82,6 +82,7 @@ function Run({ package_json_path = './package.json', argv }) {
   });
 
   this.parseArgv(argv);
+  this.rc = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
   // this is set to true after the binary.host property was set to
   // either staging_host or production_host.
@@ -254,7 +255,13 @@ proto.setBinaryHostProperty = function(command) {
   if (command === 'publish') {
     target = 'staging_host';
   }
-  if (this.opts['s3_host'] === 'staging') {
+  // each test is separate as opposed to combined like "if (this.rc[x] || this.opts[x])" to give
+  // priority to env var settings over command line.
+  if (this.rc['s3_host'] === 'staging') {
+    target = 'staging_host';
+  } else if (this.rc['s3_host'] === 'production') {
+    target = 'production_host';
+  } else if (this.opts['s3_host'] === 'staging') {
     target = 'staging_host';
   } else if (this.opts['s3_host'] === 'production') {
     target = 'production_host';

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -12,10 +12,10 @@ const napi = require('./util/napi.js');
 const s3_setup = require('./util/s3_setup.js');
 const existsAsync = fs.exists || path.exists;
 const url = require('url');
-const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function publish(gyp, argv, callback) {
   const package_json = gyp.package_json;
+  const config = gyp.rc;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
   const tarball = opts.staged_tarball;

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -9,10 +9,10 @@ const versioning = require('./util/versioning.js');
 const napi = require('./util/napi.js');
 const s3_setup = require('./util/s3_setup.js');
 const url = require('url');
-const config = require('rc')('node_pre_gyp', { acl: 'public-read' });
 
 function unpublish(gyp, argv, callback) {
   const package_json = gyp.package_json;
+  const config = gyp.rc;
   const napi_build_version = napi.get_napi_build_version_from_command_args(argv);
   const opts = versioning.evaluate(package_json, gyp.opts, napi_build_version);
 


### PR DESCRIPTION
add check for `node_pre_gyp_s3_host` env var. if present it overrides the command-line `--s3_host` option. the primary use for this is testing; it allows using the npm `install` script as it is while changing the where the binaries come from.

as part of this all but one of the `require('rc')('node_pre_gyp', {acl: 'public-read'})` statements were consolidated to a single instance in the node-pre-gyp constructor.