### PR TITLE
Respect npm_config_arch for cross-compilation scenarios

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -300,8 +300,8 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
     target: options.target || '',
     platform: options.target_platform || process.platform,
     target_platform: options.target_platform || process.platform,
-    arch: options.target_arch || process.arch,
-    target_arch: options.target_arch || process.arch,
+    arch: options.target_arch || process.env.npm_config_arch || process.arch,
+    target_arch: options.target_arch || process.env.npm_config_arch || process.arch,
     libc: options.target_libc || detect_libc.family || 'unknown',
     module_main: package_json.main,
     toolset: options.toolset || '' // address https://github.com/mapbox/node-pre-gyp/issues/119


### PR DESCRIPTION
Electron supports cross-compilation (e.g. from x64 to arm64) through the `npm_config_arch` environment variable: https://www.electronjs.org/docs/tutorial/using-native-node-modules#using-npm

`prebuild-install` checks the target architecture [in a three-step process](https://github.com/dennisameling/prebuild-install/blob/43d581a7225d1e922715b1d1e84ef98ffbcd1033/rc.js#L17):
1. `pkgConf.arch` (through running `prebuild install --arch XXX`
2. `env.npm_config_arch` for cross-compilation scenarios (e.g. a x64 host targeting arm64)
3. `process.arch` for the architecture that Node is currently running on

This PR also brings that behavior to `node-pre-gyp` 🚀 