### PR TITLE
Move aws-sdk from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "bin": "./bin/node-pre-gyp",
   "main": "./lib/node-pre-gyp.js",
   "dependencies": {
+    "aws-sdk": "^2.840.0",
     "detect-libc": "^1.0.3",
     "https-proxy-agent": "^5.0.0",
     "make-dir": "^3.1.0",
@@ -34,7 +35,6 @@
     "@mapbox/cloudfriend": "^4.6.0",
     "@mapbox/eslint-config-mapbox": "^3.0.0",
     "action-walk": "^2.2.0",
-    "aws-sdk": "^2.840.0",
     "codecov": "^3.8.1",
     "eslint": "^7.18.0",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
aws-sdk is imported here: https://github.com/mapbox/node-pre-gyp/blob/26fac61a03e74b577604db3d0ab696ba22443578/lib/util/s3_setup.js#L76

This file is included in the npm bundle, so the package should list aws-sdk as a dependency.

Right now, this breaks `esbuild` builds that have this library as a dependency