### PR TITLE
Upgrade `tar` to mitigate security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "npmlog": "^4.1.2",
     "rimraf": "^3.0.2",
     "semver": "^7.3.4",
-    "tar": "^6.1.0"
+    "tar": "^6.1.6"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^4.6.0",


### PR DESCRIPTION
Upgrade tar dependency to v.6.1.6 to mitigate the following security issues fixed in 6.1.1 and 6.1.2.

https://www.npmjs.com/advisories/1770
https://www.npmjs.com/advisories/1771