### PR TITLE
Upgrade to version 2 of detect-libc

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -302,7 +302,7 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
     target_platform: options.target_platform || process.platform,
     arch: options.target_arch || process.arch,
     target_arch: options.target_arch || process.arch,
-    libc: options.target_libc || detect_libc.family || 'unknown',
+    libc: options.target_libc || detect_libc.familySync() || 'unknown',
     module_main: package_json.main,
     toolset: options.toolset || '', // address https://github.com/mapbox/node-pre-gyp/issues/119
     bucket: package_json.binary.bucket,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mapbox/node-pre-gyp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/node-pre-gyp",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
         "make-dir": "^3.1.0",
         "node-fetch": "^2.6.5",
@@ -1309,14 +1309,11 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
+      "integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -5443,9 +5440,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
+      "integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw=="
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bin": "./bin/node-pre-gyp",
   "main": "./lib/node-pre-gyp.js",
   "dependencies": {
-    "detect-libc": "^1.0.3",
+    "detect-libc": "^2.0.0",
     "https-proxy-agent": "^5.0.0",
     "make-dir": "^3.1.0",
     "node-fetch": "^2.6.5",

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -125,7 +125,7 @@ test('should detect libc', (t) => {
     }
   };
   const opts = versioning.evaluate(mock_package_json, { module_root: '/root' });
-  const expected_libc_token = detect_libc.family || 'unknown';
+  const expected_libc_token = detect_libc.familySync() || 'unknown';
   t.comment('performing test with the following libc token: ' + expected_libc_token);
   t.equal(opts.module_path, path.normalize('/root/lib/binding/test-' + expected_libc_token));
   t.equal(opts.module, path.normalize('/root/lib/binding/test-' + expected_libc_token + '/test.node'));


### PR DESCRIPTION
Hi, the latest [detect-libc](https://www.npmjs.com/package/detect-libc) has been modernised to use the non-blocking Node.js Report API where available (Node.js >= 12), falling back to use an efficient single child process with older versions.

There's an extensive integration test suite, e.g. https://github.com/lovell/detect-libc/actions/runs/1718463728

Should anyone be interested in the background to this, please see lovell/detect-libc#14