### PR TITLE
Fix 638  Test Failing with Node 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
       node_js: 16
       env:
         - node_pre_gyp_mock_s3=true
-        - bypass_s3_tests=true
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -277,9 +277,7 @@ apps.forEach((app) => {
   });
 
   const env = process.env;
-  // bypass_s3_tests can be used to avoid these tests for node 16 temporarily to unblock travis CI.
-  // See https://github.com/mapbox/node-pre-gyp/issues/638
-  if (!env.bypass_s3_tests && (env.AWS_ACCESS_KEY_ID || env.node_pre_gyp_accessKeyId || env.node_pre_gyp_mock_s3)) {
+  if (env.AWS_ACCESS_KEY_ID || env.node_pre_gyp_accessKeyId || env.node_pre_gyp_mock_s3) {
 
     test(app.name + ' publishes ' + app.args, (t) => {
       run('node-pre-gyp', 'unpublish publish', '', app, {}, (err, stdout) => {

--- a/test/run.util.js
+++ b/test/run.util.js
@@ -57,9 +57,6 @@ function run(prog, command, args, app, opts, cb) {
   if (!opts.cwd) {
     opts.cwd = path.join(__dirname, app.name);
   }
-  // avoid breakage when compiling with clang++ and node v0.10.x
-  // This is harmless to add for other versions and platforms
-  final_cmd += ' --clang=1';
 
   // Test building with msvs 2015 since that is more edge case than 2013
   if (process.platform === 'win32') {


### PR DESCRIPTION
### Overview

This pull request fixes #638.

### Change

- Removed `clang` flag from run command. Was breaking tests when run with npm 7.x and above (node 16, 18). See [issue comment](https://github.com/mapbox/node-pre-gyp/issues/638#issuecomment-1116815545) for error details.
- Removed `env.bypass_s3_tests` conditional from tests. No longer needed.
- Updated travis workflow no longer bypassing s3 tests.