### PR TITLE
Axrj/ci fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,18 @@ dist: bionic
 
 matrix:
   include:
-    # - os: linux
-    #   node_js: 10
-    #   env:
-    #     - node_pre_gyp_mock_s3=true
-    #   before_install:
-    #     - npm install request
-    #     - npm install --package-lock-only
-    #   script:
-    #     - npm run lint
-    #     - npm run coverage
-    #   after_script:
-    #     - npm run upload-coverage
+    - os: linux
+      node_js: 10
+      env:
+        - node_pre_gyp_mock_s3=true
+      before_install:
+        - npm install request
+        - npm install --package-lock-only
+      script:
+        - npm run lint
+        - npm run coverage
+      after_script:
+        - npm run upload-coverage
     - os: linux
       node_js: 12
       env:
@@ -52,13 +52,14 @@ matrix:
         - node_pre_gyp_mock_s3=true
     # Test node webkit
     - os: linux
-      node_js: 10 # check concurrency warning message at the top
+      node_js: 10.23 # check concurrency warning message at the top
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: ['xvfb','libasound2','libx11-6','libglib2.0-0','libgtk2.0-0','libatk1.0-0','libgdk-pixbuf2.0-0','libcairo2','libfreetype6','libfontconfig1','libxcomposite1','libasound2','libxdamage1','libxext6','libxfixes3','libnss3','libnspr4','libgconf-2-4','libexpat1','libdbus-1-3','libudev1']
       script:
-        # test node-webkit usage
+        # use python2.x since it breaks with python3.x which is the default installation 
+        # https://github.com/nwjs/node/issues/46
         - mkdir ~/bin
         - ln -s /usr/bin/python2 ~/bin/python
         - ln -s /usr/bin/python2-config ~/bin/python-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,18 @@ dist: bionic
 
 matrix:
   include:
-    - os: linux
-      node_js: 10
-      env:
-        - node_pre_gyp_mock_s3=true
-      before_install:
-        - npm install request
-        - npm install --package-lock-only
-      script:
-        - npm run lint
-        - npm run coverage
-      after_script:
-        - npm run upload-coverage
+    # - os: linux
+    #   node_js: 10
+    #   env:
+    #     - node_pre_gyp_mock_s3=true
+    #   before_install:
+    #     - npm install request
+    #     - npm install --package-lock-only
+    #   script:
+    #     - npm run lint
+    #     - npm run coverage
+    #   after_script:
+    #     - npm run upload-coverage
     - os: linux
       node_js: 12
       env:
@@ -52,7 +52,7 @@ matrix:
         - node_pre_gyp_mock_s3=true
     # Test node webkit
     - os: linux
-      node_js: 10.22 # check concurrency warning message at the top
+      node_js: 10 # check concurrency warning message at the top
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,9 @@ matrix:
           packages: ['xvfb','libasound2','libx11-6','libglib2.0-0','libgtk2.0-0','libatk1.0-0','libgdk-pixbuf2.0-0','libcairo2','libfreetype6','libfontconfig1','libxcomposite1','libasound2','libxdamage1','libxext6','libxfixes3','libnss3','libnspr4','libgconf-2-4','libexpat1','libdbus-1-3','libudev1']
       script:
         # test node-webkit usage
+        - mkdir ~/bin
+        - ln -s /usr/bin/python2 ~/bin/python
+        - ln -s /usr/bin/python2-config ~/bin/python-config
         - ./scripts/test-node-webkit.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
         - node_pre_gyp_mock_s3=true
     # Test node webkit
     - os: linux
-      node_js: 10.23 # check concurrency warning message at the top
+      node_js: 10.22 # check concurrency warning message at the top
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ matrix:
       script:
         # use python2.x since it breaks with python3.x which is the default installation 
         # https://github.com/nwjs/node/issues/46
-        - mkdir ~/bin
         - ln -s /usr/bin/python2 ~/bin/python
         - ln -s /usr/bin/python2-config ~/bin/python-config
         - ./scripts/test-node-webkit.sh


### PR DESCRIPTION
Fix CI node webkit test job with python 2.x as it breaks on main with py3 default installation