### PR TITLE
Add support for nodejs-mobile

### DIFF
--- a/lib/util/compile.js
+++ b/lib/util/compile.js
@@ -10,6 +10,7 @@ const cp = require('child_process');
 
 // try to build up the complete path to node-gyp
 /* priority:
+  - node-gyp on ENV:NODEJS_MOBILE_GYP
   - node-gyp on ENV:npm_config_node_gyp (https://github.com/npm/npm/pull/4887)
   - node-gyp on NODE_PATH
   - node-gyp inside npm on NODE_PATH (ignore on iojs)
@@ -17,6 +18,17 @@ const cp = require('child_process');
 */
 function which_node_gyp() {
   let node_gyp_bin;
+  if (process.env.NODEJS_MOBILE_GYP) {
+    // nodejs-mobile was using npm_config_node_gyp, but that's currently being overwritten by npm 7+
+    try {
+      node_gyp_bin = process.env.NODEJS_MOBILE_GYP;
+      if (existsSync(node_gyp_bin)) {
+        return node_gyp_bin;
+      }
+    } catch (err) {
+      // do nothing
+    }
+  }
   if (process.env.npm_config_node_gyp) {
     try {
       node_gyp_bin = process.env.npm_config_node_gyp;


### PR DESCRIPTION
Hi,
nodejs-mobile is a fork of node used to run Node.js applications on Android and iOS.

It also allows building and running native modules. For this, it tries to use nodejs-mobile-gyp instead of node-gyp. The way it does this is setting the npm_config_node_gyp to point to nodejs-mobile-gyp. However, npm, since v7+, has started overwriting this environment variable before passing it to modules, such as node-pre-gyp.

This PR makes it so we check for the NODEJS_MOBILE_GYP environment variable to try to set node_gyp's location before trying the other methods. This variable is already used in some projects related to nodejs-mobile, so we decided to pick it:
https://github.com/nodejs-mobile/prebuild-for-nodejs-mobile/blob/44687f6cb4c0375e0f4ef063ce3321350f159241/bin.js#L367
https://github.com/nodejs-mobile/nodejs-mobile-react-native/blob/794f395152f25d1c5ccf9cc794eafa8ce58ad541/scripts/ios-build-native-modules.sh#L116
https://github.com/nodejs-mobile/nodejs-mobile-react-native/blob/794f395152f25d1c5ccf9cc794eafa8ce58ad541/android/build.gradle#L433
https://github.com/okhiroyuki/nodejs-mobile-cordova/blob/9d02c76700bba851241922d7632555546b4ee771/src/android/build.gradle#L243

The original motivation for this change was building sqlite3, which uses "@mapbox/node-pre-gyp", for nodejs-mobile. This is currently possible by adding this overrides field to a package.json of a project that's using sqlite3, but in theory it should help improve compatibility with other modules as well:
```json
  "overrides": {
    "sqlite3": {
      "@mapbox/node-pre-gyp": "github:JaneaSystems/mapbox-node-pre-gyp#add-support-for-nodejs-mobile"
    }
  }
```

We'd consider this change would be safe for current uses, since in theory a process which sets an environment variable called `NODEJS_MOBILE_GYP` is likely to want to build for nodejs-mobile.

@staltz , FYI, since this information may help unblock building other modules in nodejs-mobile.
