### PR TITLE
GitHub Actions: `npm run lint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm audit
+      - run: npm run lint
       # - run: npm run update-crosswalk  # To support newer versions of Node.js
       - run: npm run build --if-present
       - run: npm test

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -137,7 +137,7 @@ apps.forEach((app) => {
   test(app.name + ' configures with unparsed options ' + app.args, (t) => {
     run('node-pre-gyp', 'configure', '--loglevel=info -- -Dfoo=bar', app, {}, (err, stdout, stderr) => {
       t.ifError(err);
-      const clean = stdout.replaceAll('\n', '')
+      const clean = stdout.replaceAll('\n', '');
       t.equal(clean, '');
       t.ok(stderr.search(/(gyp info spawn args).*(-Dfoo=bar)/) > -1);
       t.end();

--- a/test/proxy-bcrypt.test.js
+++ b/test/proxy-bcrypt.test.js
@@ -122,9 +122,10 @@ test(`cleanup after ${__filename}`, (t) => {
   delete process.env.NOCK_OFF;
   delete process.env.http_proxy;
   delete process.env.https_proxy;
-  // ignore errors
   try {
-    rimraf(downloadDir)
-  } catch (err) {}
+    rimraf(downloadDir);
+  } catch (err) {
+    // ignore errors
+  }
   t.end();
 });

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -167,7 +167,7 @@ test('verify that the --directory option works', (t) => {
     prog = new npg.Run({ package_json_path: 'package.json', argv });
     t.fail(`should not find package.json in ${badDir}`);
   } catch (e) {
-    const exist = e.message.indexOf('ENOENT: no such file or directory')
+    const exist = e.message.indexOf('ENOENT: no such file or directory');
     t.equal(exist, 0);
   }
   t.equal(process.cwd(), initial, 'the directory should be unchanged after failing');
@@ -211,7 +211,7 @@ test('verify that a non-existent package.json fails', (t) => {
         new npg.Run({ package_json_path: dir + '/package.json' });
         t.fail('new Run() should have thrown');
       } catch (e) {
-        const exist = e.message.indexOf('ENOENT: no such file or directory')
+        const exist = e.message.indexOf('ENOENT: no such file or directory');
         t.equal(exist, 0);
       }
       t.end();


### PR DESCRIPTION
% `npm run lint`
```
> @mapbox/node-pre-gyp@1.0.11 lint
> eslint bin/node-pre-gyp lib/*js lib/util/*js test/*js scripts/*js

/[...]/node-pre-gyp/test/build.test.js
  140:48  error  Missing semicolon  semi

/[...]/node-pre-gyp/test/proxy-bcrypt.test.js
  127:24  error  Missing semicolon      semi
  128:17  error  Empty block statement  no-empty

/[...]/node-pre-gyp/test/run.test.js
  170:73  error  Missing semicolon  semi
  214:77  error  Missing semicolon  semi

✖ 5 problems (5 errors, 0 warnings)
  4 errors and 0 warnings potentially fixable with the `--fix` option.
```