### PR TITLE
upgrade nopt and add `engines` field

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ image:  # http://www.appveyor.com/docs/appveyor-yml
 
 environment:
   matrix:  # https://github.com/nodejs/release#release-schedule
-    - nodejs_version: 16
     - nodejs_version: 18
     - nodejs_version: 20
     - nodejs_version: 22

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "https-proxy-agent": "^5.0.0",
         "make-dir": "^3.1.0",
         "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
+        "nopt": "^7.2.1",
         "npmlog": "^7.0.1",
         "rimraf": "^5.0.5",
         "semver": "^7.3.5",
@@ -35,6 +35,9 @@
         "nyc": "^15.1.0",
         "tape": "^5.5.2",
         "tar-fs": "^2.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1071,9 +1074,13 @@
       "license": "ISC"
     },
     "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.12.0",
@@ -3796,17 +3803,18 @@
       "dev": true
     },
     "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
       "dependencies": {
-        "abbrev": "1"
+        "abbrev": "^2.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npmlog": {
@@ -6148,9 +6156,9 @@
       "dev": true
     },
     "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
     },
     "acorn": {
       "version": "8.12.0",
@@ -8101,11 +8109,11 @@
       "dev": true
     },
     "nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "^2.0.0"
       }
     },
     "npmlog": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,15 @@
   },
   "bin": "./bin/node-pre-gyp",
   "main": "./lib/node-pre-gyp.js",
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+  },
   "dependencies": {
     "detect-libc": "^2.0.0",
     "https-proxy-agent": "^5.0.0",
     "make-dir": "^3.1.0",
     "node-fetch": "^2.6.7",
-    "nopt": "^5.0.0",
+    "nopt": "^7.2.1",
     "npmlog": "^7.0.1",
     "rimraf": "^5.0.5",
     "semver": "^7.3.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bin": "./bin/node-pre-gyp",
   "main": "./lib/node-pre-gyp.js",
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+    "node": ">=18"
   },
   "dependencies": {
     "detect-libc": "^2.0.0",


### PR DESCRIPTION
requires a higher version of node. let's upgrade it manually so that we can specify the `engines` requirement
https://github.com/npm/nopt/blob/main/CHANGELOG.md#700-2022-11-02

edit: actually, it seems some of the other dependencies such as `tar` require Node 18, so we need to specify higher versions that what `nopt` requires