### PR TITLE
Dependabot should only open PRs for meaningful updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,12 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: "daily"
-    # Allow up to 10 open pull requests for dependencies.
-    open-pull-requests-limit: 100  # TODO: Revert to 10
   - package-ecosystem: github-actions
     directory: /
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      # Allow both direct and indirect updates for all packages.
-      - dependency-type: "all"
     # Allow up to 10 open pull requests for dependencies.
     open-pull-requests-limit: 100  # TODO: Revert to 10
   - package-ecosystem: github-actions


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow:

> By default all dependencies that are explicitly defined in a manifest are kept up to date by Dependabot version updates. In addition, Dependabot security updates also update vulnerable dependencies that are defined in lock files. 

This would be much better than our current config. Every single dependabot PR that's passing the CI currently looks to be just noise as none of them affect users and only affect our own lockfile. This makes it difficult to tell which PRs are actually meaningful as they're hidden amongst the ones with no impact.