### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,20 @@
 # For all possible configuration options see:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+# Note that limitations on version updates applied in this file don't apply to security updates,
+# which are separately managed by dependabot
+
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    # Allow up to 10 open pull requests for dependencies.
-    open-pull-requests-limit: 5
-  - package-ecosystem: github-actions
-    directory: /
-    groups:
-      github-actions:
-        patterns:
-          - "*"  # Group all Actions updates into a single larger pull request
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "daily"


### PR DESCRIPTION
There are a few issues with the current dependabot config:

- the first group name is wrong. https://github.com/mapbox/node-pre-gyp/pull/874 is updating npm, but it says `github-actions`
- we should avoid grouping because it makes it very hard to handle updates. E.g. https://github.com/mapbox/node-pre-gyp/pull/874 is failing. If it were ungrouped then we could merge the working ones, but now they're all blocked
- daily updates of github actions are probably fine as they will be rare. Dependabot hasn't opened any PRs for github actions yet
- we can skip patch and minor releases. This is the most important thing to change as it generates tons of noise otherwise
- the comment above the limit is incorrect
- the limit is currently set to the default limit, which is unnecessary
- I don't think we need such a low limit if it we're more selective about which updates to attempt