### PR TITLE
Remove 'martinbeentjes/npm-get-version-action' from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,13 @@ jobs:
         run: |
           currentVersion="$( node -e "console.log(require('./package.json').version)" )"
           isPublished="$( npm view @mapbox/node-pre-gyp versions --json | jq -c --arg cv "$currentVersion" 'any(. == $cv)' )"
+          echo "version=$currentVersion" >> "$GITHUB_OUTPUT"
           echo "published=$isPublished" >> "$GITHUB_OUTPUT"
           echo "currentVersion: $currentVersion"
           echo "isPublished: $isPublished"
     outputs:
       published: ${{ steps.check.outputs.published }}
+      version: ${{ steps.check.outputs.version }}
 
   publish:
     needs: release-check
@@ -58,15 +60,11 @@ jobs:
       - run: npm run build --if-present
       
       - run: npm test
- 
-      - name: Get version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.3.1
 
       - name: Prepare release changelog
         id: prepare_release
         run: |
-          RELEASE_TYPE="$(node -e "console.log(require('semver').prerelease('${{ steps.package-version.outputs.current-version }}') ? 'prerelease' : 'regular')")"
+          RELEASE_TYPE="$(node -e "console.log(require('semver').prerelease('${{ needs.release-check.outputs.version }}') ? 'prerelease' : 'regular')")"
           if [[ $RELEASE_TYPE == 'regular' ]]; then
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           else
@@ -75,7 +73,7 @@ jobs:
 
       - name: Extract changelog for version
         run: |
-          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "## ${{ steps.package-version.outputs.current-version }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
+          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "## ${{ needs.release-check.outputs.version }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
           cat changelog_for_version.md
 
       - name: Publish to Github
@@ -83,8 +81,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: v${{ steps.package-version.outputs.current-version }}
-          name: v${{ steps.package-version.outputs.current-version }}
+          tag: v${{ needs.release-check.outputs.version }}
+          name: v${{ needs.release-check.outputs.version }}
           bodyFile: changelog_for_version.md
           allowUpdates: true
           draft: false


### PR DESCRIPTION
Removes the 'martinbeentjes/npm-get-version-action' from the release workflow. 

I am already getting this value in the first job, so I just added that to the outputs and used that variable where 'steps.package-version.outputs.current-version' was used before.

I tested this in my fork and it looks like it pulls the version as expected
https://github.com/WifiDB/node-pre-gyp/actions/runs/12215279116
https://github.com/WifiDB/node-pre-gyp/releases/tag/v2.0.0-rc.3
https://www.npmjs.com/package/@acalcutt/node-pre-gyp-test/v/2.0.0-rc.3