### PR TITLE
Release v2.0.0-rc.0 (example)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # node-pre-gyp changelog
 
-## Unreleased
-
 ## 2.0.0-rc.0
 - Supported Node versions are now stable versions of Node 18+. We will attempt to track the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) and will regularly retire support for versions that have reached EOL.
 - Fixed use of `s3ForcePathStyle` for installation [#650](https://github.com/mapbox/node-pre-gyp/pull/650)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # node-pre-gyp changelog
 
+## Unreleased
+
 ## 2.0.0-rc.0
 - Supported Node versions are now stable versions of Node 18+. We will attempt to track the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) and will regularly retire support for versions that have reached EOL.
 - Fixed use of `s3ForcePathStyle` for installation [#650](https://github.com/mapbox/node-pre-gyp/pull/650)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # node-pre-gyp changelog
 
-## Unreleased - 2.0.0
+## 2.0.0-rc.0
 - Supported Node versions are now stable versions of Node 18+. We will attempt to track the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) and will regularly retire support for versions that have reached EOL.
 - Fixed use of `s3ForcePathStyle` for installation [#650](https://github.com/mapbox/node-pre-gyp/pull/650)
 - Upgraded to https-proxy-agent 7.0.5, nopt 8.0.0, semver 7.5.3, and tar 7.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/node-pre-gyp",
-  "version": "1.0.11",
+  "version": "2.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/node-pre-gyp",
-      "version": "1.0.11",
+      "version": "2.0.0-rc.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "consola": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/node-pre-gyp",
   "description": "Node.js native addon binary install tool",
-  "version": "1.0.11",
+  "version": "2.0.0-rc.0",
   "keywords": [
     "native",
     "addon",


### PR DESCRIPTION
This is a example of a PR to create a 'v2.0.0-rc.0' release.

I ran 
`npm version premajor --preid rc --no-git-tag-version`

and updated CHANGELOG.md so it has a section for the new version. *note* the 'v' in the version is not used in CHANGELOG.md .it needs to match with is in package.json which doesn't have a 'v'.

Just a note. typically when I release multiple pre-releases, I just change the version in CHANGELOG.md on the last pre-release and use the same text and don't recreate all the same text twice under a new header, until it gets replaced by the final release version. But that is just a preference, you can make a new entry for each release if that is what you want.