### PR TITLE
GitHub Actions: Add ubuntu-24.04-arm to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
   ci:
     strategy:
       fail-fast: false
-      max-parallel: 9
       matrix:
-        node-version: ['18.x', '20.x', '22.x']
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        node-version: ['18.x', '20.x', 'lts/*']
+        os: [macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[actions/setup-node Supported version syntax](https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax) --> `lts/*`

[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`