### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # node-pre-gyp changelog
 
 ## master
+
+## 2.0.1
 - Update abi_crosswalk.json for abi 137 / node 24 (https://github.com/mapbox/node-pre-gyp/pull/904)
 
 ## 2.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/node-pre-gyp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/node-pre-gyp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "consola": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/node-pre-gyp",
   "description": "Node.js native addon binary install tool",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "native",
     "addon",


### PR DESCRIPTION
Publish Release v2.0.1, which includes an update abi_crosswalk.json for abi 137 / node 24 (#904) and dependency updates in Upgrade tar-fs && npm install && npm audit fix (#900)
