### PR TITLE
fix moduleName environment for multiple dashes

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -312,7 +312,7 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
     // support host mirror with npm config `--{module_name}_binary_host_mirror`
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://registry.npmmirror.com/node-inspector/
-  const validModuleName = opts.module_name.replace('-', '_');
+  const validModuleName = opts.module_name.replaceAll('-', '_');
   const host = process.env['npm_config_' + validModuleName + '_binary_host_mirror'] || package_json.binary.host;
   opts.host = fix_slashes(eval_template(host, opts));
   opts.module_path = eval_template(package_json.binary.module_path, opts);


### PR DESCRIPTION
Fix #896 by using `replaceAll` instead of `replace`