### PR TITLE
fix: revert "Bump nopt from 8.0.0 to 9.0.0 (#919)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^2.6.7",
-        "nopt": "^9.0.0",
+        "nopt": "^8.0.0",
         "semver": "^7.5.3",
         "tar": "^7.4.0"
       },
@@ -2422,12 +2422,12 @@
       "license": "ISC"
     },
     "node_modules/abbrev": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/acorn": {
@@ -5698,18 +5698,18 @@
       "license": "MIT"
     },
     "node_modules/nopt": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.0.0.tgz",
+      "integrity": "sha512-1L/fTJ4UmV/lUxT2Uf006pfZKTvAgCF+chz+0OgBHO8u2Z67pE7AaAUUj7CJy0lXqHmymUvGFt6NE9R3HER0yw==",
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^4.0.0"
+        "abbrev": "^2.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/nyc": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "detect-libc": "^2.0.0",
     "https-proxy-agent": "^7.0.5",
     "node-fetch": "^2.6.7",
-    "nopt": "^9.0.0",
+    "nopt": "^8.0.0",
     "semver": "^7.5.3",
     "tar": "^7.4.0"
   },


### PR DESCRIPTION
This reverts commit c842373a353e7c9478152bd9e36f6de02d59f521.

Fixes https://github.com/mapbox/node-pre-gyp/issues/924.