### PR TITLE
Migrate off deprecated `url.parse` APIS to WHATWG URL API instead.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -11,7 +11,7 @@ const existsAsync = fs.exists || path.exists;
 const versioning = require('./util/versioning.js');
 const napi = require('./util/napi.js');
 const s3_setup = require('./util/s3_setup.js');
-const url = require('url');
+const url = require('./util/url.js');
 // for fetching binaries
 const fetch = require('node-fetch');
 const tar = require('tar');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,7 +11,7 @@ const versioning = require('./util/versioning.js');
 const napi = require('./util/napi.js');
 const s3_setup = require('./util/s3_setup.js');
 const existsAsync = fs.exists || path.exists;
-const url = require('url');
+const url = require('./util/url.js');
 
 function publish(gyp, argv, callback) {
   const package_json = gyp.package_json;

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -8,7 +8,7 @@ const log = require('./util/log.js');
 const versioning = require('./util/versioning.js');
 const napi = require('./util/napi.js');
 const s3_setup = require('./util/s3_setup.js');
-const url = require('url');
+const url = require('./util/url.js');
 
 function unpublish(gyp, argv, callback) {
   const package_json = gyp.package_json;

--- a/lib/util/s3_setup.js
+++ b/lib/util/s3_setup.js
@@ -28,7 +28,7 @@ module.exports.detect = function(opts) {
     // https://bucket-name.s3.Region.amazonaws.com/key-name (dash Region)
     // or in some legacy region of this format:
     // https://bucket-name.s3-Region.amazonaws.com/key-name (dot Region)
-    const parts = uri.hostname.split('.s3');
+    const parts = uri.hostname.replace(/^\[|\]$/, '').split('.s3');
 
     // there is nothing before the .s3
     // not a valid s3 virtual host bucket url

--- a/lib/util/s3_setup.js
+++ b/lib/util/s3_setup.js
@@ -28,7 +28,7 @@ module.exports.detect = function(opts) {
     // https://bucket-name.s3.Region.amazonaws.com/key-name (dash Region)
     // or in some legacy region of this format:
     // https://bucket-name.s3-Region.amazonaws.com/key-name (dot Region)
-    const parts = uri.hostname.replace(/^\[|\]$/, '').split('.s3');
+    const parts = uri.hostname.split('.s3');
 
     // there is nothing before the .s3
     // not a valid s3 virtual host bucket url

--- a/lib/util/s3_setup.js
+++ b/lib/util/s3_setup.js
@@ -2,13 +2,12 @@
 
 module.exports = exports;
 
-const url = require('url');
 
 module.exports.detect = function(opts) {
   const config = {};
 
   const to = opts.hosted_path;
-  const uri = url.parse(to);
+  const uri = new URL(to);
 
   if (opts.bucket && opts.region) {
     // use user defined settings for host, region, bucket
@@ -29,7 +28,7 @@ module.exports.detect = function(opts) {
     // https://bucket-name.s3.Region.amazonaws.com/key-name (dash Region)
     // or in some legacy region of this format:
     // https://bucket-name.s3-Region.amazonaws.com/key-name (dot Region)
-    const parts = uri.hostname.split('.s3');
+    const parts = uri.hostname.replace(/^\[|\]$/, '').split('.s3');
 
     // there is nothing before the .s3
     // not a valid s3 virtual host bucket url

--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -1,6 +1,8 @@
+'use strict';
+
 // url.resolve is deprecated because it invokes the deprecated url.parse() internally
 // https://nodejs.org/api/url.html#urlresolvefrom-to
-module.exports.resolve = function (from, to) {
+module.exports.resolve = function(from, to) {
   const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
   if (resolvedUrl.protocol === 'resolve:') {
     // `from` is a relative URL.

--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -7,6 +7,12 @@ module.exports.resolve = function(from, to) {
   if (resolvedUrl.protocol === 'resolve:') {
     // `from` is a relative URL.
     const { pathname, search, hash } = resolvedUrl;
+
+    // To keep consistency with deprecated url.resolve(), we need to remove the leading '/' from pathname
+    if (pathname[0] === '/') {
+      return pathname.slice(1) + search + hash;
+    }
+
     return pathname + search + hash;
   }
   return resolvedUrl.toString();

--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -1,0 +1,11 @@
+// url.resolve is deprecated because it invokes the deprecated url.parse() internally
+// https://nodejs.org/api/url.html#urlresolvefrom-to
+module.exports.resolve = function (from, to) {
+  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    // `from` is a relative URL.
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
+};

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -4,7 +4,6 @@ module.exports = exports;
 
 const path = require('path');
 const semver = require('semver');
-const url = require('url');
 const detect_libc = require('detect-libc');
 const napi = require('./napi.js');
 
@@ -241,6 +240,18 @@ function eval_template(template, opts) {
   return template;
 }
 
+// url.resolve is deprecated because it invokes the deprecated url.parse() internally
+// https://nodejs.org/api/url.html#urlresolvefrom-to
+function url_resolve(from, to) {
+  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    // `from` is a relative URL.
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
+}
+
 // url.resolve needs single trailing slash
 // to behave correctly, otherwise a double slash
 // may end up in the url which breaks requests
@@ -333,10 +344,10 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
   // when using s3ForcePathStyle the bucket is part of the http object path
   // add it
   if (opts.s3ForcePathStyle) {
-    opts.hosted_path = url.resolve(opts.host, drop_double_slashes(`${opts.bucket}/${opts.remote_path}`));
+    opts.hosted_path = url_resolve(opts.host, drop_double_slashes(`${opts.bucket}/${opts.remote_path}`));
   } else {
-    opts.hosted_path = url.resolve(opts.host, opts.remote_path);
+    opts.hosted_path = url_resolve(opts.host, opts.remote_path);
   }
-  opts.hosted_tarball = url.resolve(opts.hosted_path, opts.package_name);
+  opts.hosted_tarball = url_resolve(opts.hosted_path, opts.package_name);
   return opts;
 };

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -221,9 +221,13 @@ function validate_config(package_json, opts) {
   }
   if (o) {
     // enforce https over http
-    const protocol = new URL(o.host).protocol;
-    if (protocol === 'http:') {
-      throw new Error("'host' protocol (" + protocol + ") is invalid - only 'https:' is accepted");
+    try {
+      const protocol = new URL(o.host).protocol;
+      if (protocol === 'http:') {
+        throw new Error("'host' protocol (" + protocol + ") is invalid - only 'https:' is accepted");
+      }
+    } catch (err) {
+      // do nothing
     }
   }
   napi.validate_package_json(package_json, opts);

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -241,7 +241,6 @@ function eval_template(template, opts) {
   return template;
 }
 
-
 // url.resolve needs single trailing slash
 // to behave correctly, otherwise a double slash
 // may end up in the url which breaks requests

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -6,6 +6,7 @@ const path = require('path');
 const semver = require('semver');
 const detect_libc = require('detect-libc');
 const napi = require('./napi.js');
+const url = require('./url.js');
 
 let abi_crosswalk;
 
@@ -240,17 +241,6 @@ function eval_template(template, opts) {
   return template;
 }
 
-// url.resolve is deprecated because it invokes the deprecated url.parse() internally
-// https://nodejs.org/api/url.html#urlresolvefrom-to
-function url_resolve(from, to) {
-  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
-  if (resolvedUrl.protocol === 'resolve:') {
-    // `from` is a relative URL.
-    const { pathname, search, hash } = resolvedUrl;
-    return pathname + search + hash;
-  }
-  return resolvedUrl.toString();
-}
 
 // url.resolve needs single trailing slash
 // to behave correctly, otherwise a double slash
@@ -344,10 +334,10 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
   // when using s3ForcePathStyle the bucket is part of the http object path
   // add it
   if (opts.s3ForcePathStyle) {
-    opts.hosted_path = url_resolve(opts.host, drop_double_slashes(`${opts.bucket}/${opts.remote_path}`));
+    opts.hosted_path = url.resolve(opts.host, drop_double_slashes(`${opts.bucket}/${opts.remote_path}`));
   } else {
-    opts.hosted_path = url_resolve(opts.host, opts.remote_path);
+    opts.hosted_path = url.resolve(opts.host, opts.remote_path);
   }
-  opts.hosted_tarball = url_resolve(opts.hosted_path, opts.package_name);
+  opts.hosted_tarball = url.resolve(opts.hosted_path, opts.package_name);
   return opts;
 };

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -221,7 +221,7 @@ function validate_config(package_json, opts) {
   }
   if (o) {
     // enforce https over http
-    const protocol = url.parse(o.host).protocol;
+    const protocol = new URL(o.host).protocol;
     if (protocol === 'http:') {
       throw new Error("'host' protocol (" + protocol + ") is invalid - only 'https:' is accepted");
     }


### PR DESCRIPTION
This PR attempts to remove the following warnings when using this library:

```
(node:960561) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Node itself provides a codemod (`npx codemod@latest @nodejs/node-url-to-whatwg-url`) that mainly replaces `url.parse`.

`url.resolve` is also widely used and their d[ocs provide an example](https://nodejs.org/api/url.html#urlresolvefrom-to) on how to replace it using the modern WHATWG URL API.