### PR TITLE
Avoid npm warnings by supporting MODULE_BINARY_HOST_MIRROR env variable

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -314,7 +314,8 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://registry.npmmirror.com/node-inspector/
   const validModuleName = opts.module_name.replace('-', '_');
-  const host = process.env['npm_config_' + validModuleName + '_binary_host_mirror'] || package_json.binary.host;
+  const envNameSuffix = validModuleName + '_binary_host_mirror';
+  const host = process.env['npm_config_' + envNameSuffix] || process.env[envNameSuffix.toUpperCase()] || package_json.binary.host;
   opts.host = fix_slashes(eval_template(host, opts));
   opts.module_path = eval_template(package_json.binary.module_path, opts);
   // now we resolve the module_path to ensure it is absolute so that binding.gyp variables work predictably

--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -313,7 +313,7 @@ module.exports.evaluate = function(package_json, options, napi_build_version) {
     // support host mirror with npm config `--{module_name}_binary_host_mirror`
     // e.g.: https://github.com/node-inspector/v8-profiler/blob/master/package.json#L25
     // > npm install v8-profiler --profiler_binary_host_mirror=https://registry.npmmirror.com/node-inspector/
-  const validModuleName = opts.module_name.replace('-', '_');
+  const validModuleName = opts.module_name.replace(/-/g, '_');
   const envNameSuffix = validModuleName + '_binary_host_mirror';
   const host = process.env['npm_config_' + envNameSuffix] || process.env[envNameSuffix.toUpperCase()] || package_json.binary.host;
   opts.host = fix_slashes(eval_template(host, opts));

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -181,6 +181,26 @@ test('should detect custom binary host from env', (t) => {
   t.end();
 });
 
+test('should detect custom binary host from uppercase env', (t) => {
+  const mock_package_json = {
+    'name': 'test',
+    'main': 'test.js',
+    'version': '0.1.0',
+    'binary': {
+      'module_name': 'test',
+      'module_path': './lib/binding/{configuration}/{toolset}/{name}',
+      'remote_path': './{name}/v{version}/{configuration}/{version}/{toolset}/',
+      'package_name': '{module_name}-v{major}.{minor}.{patch}-{prerelease}+{build}-{toolset}-{node_abi}-{platform}-{arch}.tar.gz',
+      'host': 'https://some-bucket.s3.us-east-1.amazonaws.com'
+    }
+  };
+  process.env.TEST_BINARY_HOST_MIRROR = 'https://registry.npmmirror.com/node-inspector/';
+  const opts = versioning.evaluate(mock_package_json, {});
+  t.equal(opts.host, 'https://registry.npmmirror.com/node-inspector/');
+  delete process.env.TEST_BINARY_HOST_MIRROR;
+  t.end();
+});
+
 test('should detect libc', (t) => {
   const mock_package_json = {
     'name': 'test',


### PR DESCRIPTION
## Description
With newer versions of npm (v10+), using environment variables in the form of:
```
npm_config_<module>_binary_host_mirror
```
will trigger warnings such as:
```
npm warn Unknown env config "<module>-binary-host-mirror"
```
This happens because npm now validates environment variables prefixed with npm_config_* against its known configuration keys, and custom keys used by tools like node-pre-gyp are no longer recognized.

## Changes

To address this issue, this PR introduces support for an alternative environment variable:
```
<MODULE>_BINARY_HOST_MIRROR
```
Specifically:

The code now checks for `npm_config_<module>_binary_host_mirror` 
Falls back to `process.env.<MODULE>_BINARY_HOST_MIRROR`